### PR TITLE
Draft: show non-matched installed addons

### DIFF
--- a/wowup-electron/src/app/addon-providers/tukui-addon-provider.ts
+++ b/wowup-electron/src/app/addon-providers/tukui-addon-provider.ts
@@ -137,6 +137,9 @@ export class TukUiAddonProvider implements AddonProvider {
     addonFolders: AddonFolder[]
   ): Promise<void> {
     const allAddons = await this.getAllAddons(clientType);
+
+    let knownFolders = {};
+
     for (let addonFolder of addonFolders) {
       let tukUiAddon: TukUiAddon;
       if (addonFolder.toc?.tukUiProjectId) {
@@ -153,7 +156,7 @@ export class TukUiAddonProvider implements AddonProvider {
       }
 
       if (tukUiAddon) {
-        addonFolder.matchingAddon = {
+        let addon = {
           autoUpdateEnabled: false,
           channelType: addonChannelType,
           clientType: clientType,
@@ -177,8 +180,21 @@ export class TukUiAddonProvider implements AddonProvider {
           screenshotUrls: [tukUiAddon.screenshot_url],
           releasedAt: new Date(`${tukUiAddon.lastupdate} UTC`),
         };
+        if (addonFolder.toc.tukUiProjectFolders) {
+          for (let tukUiFolder of addonFolder.toc.tukUiProjectFolders.split(',')) {
+            knownFolders[tukUiFolder] = addon;
+          }
+        }
+        addonFolder.matchingAddon = addon;
       }
     }
+
+    for (let addonFolder of addonFolders) {
+      if (!addonFolder.matchingAddon && addonFolder.name in knownFolders) {
+        addonFolder.matchingAddon = knownFolders[addonFolder.name];
+      }
+    }
+
   }
 
   private async searchAddons(addonName: string, clientType: WowClientType) {

--- a/wowup-electron/src/app/models/wowup/toc.ts
+++ b/wowup-electron/src/app/models/wowup/toc.ts
@@ -13,4 +13,5 @@ export interface Toc {
   tukUiProjectId?: string;
   tukUiProjectFolders?: string;
   modificationDate?: Date;
+  creationDate?: Date;
 }

--- a/wowup-electron/src/app/models/wowup/toc.ts
+++ b/wowup-electron/src/app/models/wowup/toc.ts
@@ -12,4 +12,5 @@ export interface Toc {
   wowInterfaceId?: string;
   tukUiProjectId?: string;
   tukUiProjectFolders?: string;
+  modificationDate?: Date;
 }

--- a/wowup-electron/src/app/services/addons/addon.service.ts
+++ b/wowup-electron/src/app/services/addons/addon.service.ts
@@ -513,7 +513,7 @@ export class AddonService {
     return Object.values(matchedGroups).map((value) => value[0].matchingAddon).concat(
         nonMatchedFolders.map((folder) => {
           let addon: Addon = {
-            id: folder.name,
+            id: uuidv4(),
             name: folder.toc.title,
             installedFolders: folder.name,
             isIgnored: false,

--- a/wowup-electron/src/app/services/addons/addon.service.ts
+++ b/wowup-electron/src/app/services/addons/addon.service.ts
@@ -526,6 +526,8 @@ export class AddonService {
             externalUrl: folder.toc.website,
             latestVersion: folder.toc.version,
             releasedAt: folder.toc.modificationDate,
+            updatedAt: folder.toc.modificationDate,
+            installedAt: folder.toc.creationDate,
           };
           return addon;
         })

--- a/wowup-electron/src/app/services/addons/addon.service.ts
+++ b/wowup-electron/src/app/services/addons/addon.service.ts
@@ -503,15 +503,33 @@ export class AddonService {
       }
     }
 
+    const nonMatchedFolders = addonFolders.filter((af) => !af.matchingAddon && af.toc);
     const matchedAddonFolders = addonFolders.filter((addonFolder) => !!addonFolder.matchingAddon);
     const matchedGroups = _.groupBy(
       matchedAddonFolders,
       (addonFolder) => `${addonFolder.matchingAddon.providerName}${addonFolder.matchingAddon.externalId}`
     );
 
-    console.log(Object.keys(matchedGroups));
-
-    return Object.values(matchedGroups).map((value) => value[0].matchingAddon);
+    return Object.values(matchedGroups).map((value) => value[0].matchingAddon).concat(
+        nonMatchedFolders.map((folder) => {
+          let addon: Addon = {
+            id: folder.name,
+            name: folder.toc.title,
+            folderName: folder.path,
+            isIgnored: false,
+            autoUpdateEnabled: false,
+            clientType: clientType,
+            channelType: AddonChannelType.Stable,
+            installedVersion: folder.toc.version,
+            author: folder.toc.author,
+            gameVersion: folder.toc.interface,
+            externalUrl: folder.toc.website,
+            latestVersion: folder.toc.version,
+            releasedAt: folder.toc.modificationDate,
+          };
+          return addon;
+        })
+      );
   }
 
   public getFeaturedAddons(clientType: WowClientType): Observable<AddonSearchResult[]> {

--- a/wowup-electron/src/app/services/addons/addon.service.ts
+++ b/wowup-electron/src/app/services/addons/addon.service.ts
@@ -515,7 +515,7 @@ export class AddonService {
           let addon: Addon = {
             id: folder.name,
             name: folder.toc.title,
-            folderName: folder.path,
+            installedFolders: folder.name,
             isIgnored: false,
             autoUpdateEnabled: false,
             clientType: clientType,

--- a/wowup-electron/src/app/services/toc/toc.service.ts
+++ b/wowup-electron/src/app/services/toc/toc.service.ts
@@ -13,6 +13,7 @@ export class TocService {
     const tocText = await this._fileService.readFile(tocPath);
     const tocFsStat = await FileUtils.getFileModificationTime(tocPath);
     const modificationDate = tocFsStat.mtime;
+    const creationDate = tocFsStat.ctime;
 
     return {
       author: this.getValue("Author", tocText),
@@ -29,6 +30,7 @@ export class TocService {
       tukUiProjectId: this.getValue("X-Tukui-ProjectID", tocText),
       tukUiProjectFolders: this.getValue("X-Tukui-ProjectFolders", tocText),
       modificationDate: modificationDate,
+      creationDate: creationDate,
     };
   }
 

--- a/wowup-electron/src/app/services/toc/toc.service.ts
+++ b/wowup-electron/src/app/services/toc/toc.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from "@angular/core";
 import { Toc } from "../../models/wowup/toc";
 import { FileService } from "../files/file.service";
+import { FileUtils } from "../../utils/file.utils";
 
 @Injectable({
   providedIn: "root",
@@ -10,6 +11,8 @@ export class TocService {
 
   public async parse(tocPath: string): Promise<Toc> {
     const tocText = await this._fileService.readFile(tocPath);
+    const tocFsStat = await FileUtils.getFileModificationTime(tocPath);
+    const modificationDate = tocFsStat.mtime;
 
     return {
       author: this.getValue("Author", tocText),
@@ -25,6 +28,7 @@ export class TocService {
       dependencies: this.getValue("Dependencies", tocText),
       tukUiProjectId: this.getValue("X-Tukui-ProjectID", tocText),
       tukUiProjectFolders: this.getValue("X-Tukui-ProjectFolders", tocText),
+      modificationDate: modificationDate,
     };
   }
 

--- a/wowup-electron/src/app/utils/file.utils.ts
+++ b/wowup-electron/src/app/utils/file.utils.ts
@@ -3,6 +3,7 @@ import * as util from "util";
 
 const fsAccess = util.promisify(fs.access);
 const fsReadFile = util.promisify(fs.readFile);
+const fsStat = util.promisify(fs.stat);
 
 export class FileUtils {
   static async exists(path: string) {
@@ -20,5 +21,12 @@ export class FileUtils {
 
   static readFileSync(path: string) {
     return fs.readFileSync(path);
+  }
+
+  static async getFileModificationTime(path: string) {
+    try {
+      return await fsStat(path);
+    } catch (e) {
+    }
   }
 }


### PR DESCRIPTION
Shows addons non-matched by curse fingerprint

![image](https://user-images.githubusercontent.com/2664578/98394994-9f885180-206c-11eb-9c0f-77047fd8a9ac.png)

Cons:
Non-linked folder does not group up.  
So for modified dependencies it doubles in UI
![image](https://user-images.githubusercontent.com/2664578/98395744-c1ce9f00-206d-11eb-94f0-e14d99f03f91.png)
