### PR TITLE
Fixed a null pointer when no release is found via "Install from URL"

### DIFF
--- a/wowup-electron/src/app/addon-providers/github-addon-provider.ts
+++ b/wowup-electron/src/app/addon-providers/github-addon-provider.ts
@@ -57,10 +57,13 @@ export class GitHubAddonProvider implements AddonProvider {
 
     const results = await this.getReleases(repoPath).toPromise();
     const latestRelease = this.getLatestRelease(results);
-    const asset = this.getValidAsset(latestRelease, clientType);
+    if (!latestRelease) {
+      throw new Error(`No release found in ${addonUri}`);
+    }
 
+    const asset = this.getValidAsset(latestRelease, clientType);
     if (asset == null) {
-      throw new Error(`No release found: ${addonUri}`);
+      throw new Error(`No release assets found in ${addonUri}`);
     }
 
     var repository = await this.getRepository(repoPath).toPromise();


### PR DESCRIPTION
No translations yet, because this is not a service. The problem was that the repository had only tags, no releases, and thus the function failed with a null pointer inside `getValidAsset`. I've also slightly improved the error messages to help figure out what's wrong.

### Original error
![image](https://user-images.githubusercontent.com/1754678/98462039-660d2e80-21b1-11eb-90b4-2bbffda112eb.png)
