### PR TITLE
Updated horde and alliance theme colors to be more readable

### DIFF
--- a/wowup-electron/src/variables.scss
+++ b/wowup-electron/src/variables.scss
@@ -22,11 +22,11 @@ $epic-color: #a335ee;
 $artifact: #dbcc78;
 
 // HORDE
-$horde-red-1: #8c1616;
-$horde-red-2: #6e1d1d;
-$horde-red-3: #5e1d1d;
+$horde-red-1: #8c1616; // Header Color
+$horde-red-2: #ff8e8e; // Option toggle color
+$horde-red-3: #ef8e8e; // Scroll bar toggle color
 
 // ALLIANCE
-$alliance-blue-1: #34488b;
-$alliance-blue-2: #33437a;
-$alliance-blue-3: #2a355a;
+$alliance-blue-1: #162c57; // Header color
+$alliance-blue-2: #8ea4cf; // Option toggle color
+$alliance-blue-3: #7ea4cf; // Scroll bar toggle color


### PR DESCRIPTION
This is a simple tweak to the theme colors to enable better visibility to the options page.

I used the standard hex code for wow alliance blue which helps it to stand out more.

Examples of changes.

Main header color for alliance as well as buttons.
![image](https://user-images.githubusercontent.com/1172935/99154796-55543100-2667-11eb-9c80-5e3ad20b1c71.png)

Alliance option toggles:
![image](https://user-images.githubusercontent.com/1172935/99154806-73219600-2667-11eb-8016-15c47386846d.png)

Horde option toggles:
![image](https://user-images.githubusercontent.com/1172935/99154813-846aa280-2667-11eb-857d-9774b5f1f076.png)

