### PR TITLE
Theme tweaks

### DIFF
--- a/wowup-electron/src/custom-theme.scss
+++ b/wowup-electron/src/custom-theme.scss
@@ -153,6 +153,14 @@ $horde-theme: mat-dark-theme(
     background-color: $horde-red-2 !important;
   }
 
+  .mat-form-field-ripple {
+    background-color: $horde-red-2 !important;
+  }
+
+  .mat-form-field.mat-focused .mat-form-field-label {
+    color: $horde-red-2 !important;
+  }
+
   ::-webkit-scrollbar-track {
     background-color: $dark-2;
   }
@@ -172,7 +180,7 @@ $horde-theme: mat-dark-theme(
 $alliance-pallette: (
   50: #e8eaf6,
   100: $alliance-blue-1,
-  200: #504fa1,
+  200: $alliance-blue-2,
   300: #383773,
   400: #5c6bc0,
   500: #3f51b5,
@@ -227,6 +235,14 @@ $alliance-theme: mat-dark-theme(
 
   .hover-primary-2:hover {
     background-color: $alliance-blue-3 !important;
+  }
+
+  .mat-form-field-ripple {
+    background-color: $alliance-blue-2 !important;
+  }
+
+  .mat-form-field.mat-focused .mat-form-field-label {
+    color: $alliance-blue-2 !important;
   }
 
   ::-webkit-scrollbar-track {

--- a/wowup-electron/src/custom-theme.scss
+++ b/wowup-electron/src/custom-theme.scss
@@ -105,7 +105,7 @@ $horde-pallette: (
   800: #283593,
   900: #1a237e,
   A100: $horde-red-1,
-  A200: $horde-red-2,
+  A200: $horde-control,
   A400: $horde-red-3,
   A700: #6874bb,
   contrast: (
@@ -157,10 +157,6 @@ $horde-theme: mat-dark-theme(
     background-color: $horde-red-2 !important;
   }
 
-  .mat-form-field.mat-focused .mat-form-field-label {
-    color: $horde-red-2 !important;
-  }
-
   ::-webkit-scrollbar-track {
     background-color: $dark-2;
   }
@@ -189,7 +185,7 @@ $alliance-pallette: (
   800: #283593,
   900: #1a237e,
   A100: $alliance-blue-1,
-  A200: $alliance-blue-2,
+  A200: $alliance-control,
   A400: $alliance-blue-3,
   A700: #6874bb,
   contrast: (
@@ -239,10 +235,6 @@ $alliance-theme: mat-dark-theme(
 
   .mat-form-field-ripple {
     background-color: $alliance-blue-2 !important;
-  }
-
-  .mat-form-field.mat-focused .mat-form-field-label {
-    color: $alliance-blue-2 !important;
   }
 
   ::-webkit-scrollbar-track {

--- a/wowup-electron/src/styles.scss
+++ b/wowup-electron/src/styles.scss
@@ -430,6 +430,13 @@ snack-bar-container {
   z-index: 2;
 }
 
+.mat-input-element {
+  caret-color: $white-3 !important;
+}
+.mat-form-field.mat-focused .mat-form-field-label {
+  color: $white-2 !important;
+}
+
 th.mat-header-cell .mat-sort-header-container.mat-sort-header-sorted .mat-sort-header-arrow {
   opacity: 1 !important;
   transform: translateY(0) !important;

--- a/wowup-electron/src/variables.scss
+++ b/wowup-electron/src/variables.scss
@@ -22,11 +22,11 @@ $epic-color: #a335ee;
 $artifact: #dbcc78;
 
 // HORDE
-$horde-red-1: #8c1616;
-$horde-red-2: #6e1d1d;
-$horde-red-3: #5e1d1d;
+$horde-red-1: #8c1616; // Header Color
+$horde-red-2: #ff8e8e; // Option toggle color
+$horde-red-3: #ef8e8e; // Scroll bar toggle color
 
 // ALLIANCE
-$alliance-blue-1: #34488b;
-$alliance-blue-2: #33437a;
-$alliance-blue-3: #2a355a;
+$alliance-blue-1: #162c57; // Header color
+$alliance-blue-2: #8ea4cf; // Option toggle color
+$alliance-blue-3: #7ea4cf; // Scroll bar toggle color

--- a/wowup-electron/src/variables.scss
+++ b/wowup-electron/src/variables.scss
@@ -2,10 +2,10 @@ $blue-1: #315891;
 $blue-2: #24416c;
 $highlight: #01baef;
 
-$dark-1: #555555;
-$dark-2: #444444;
-$dark-3: #333333;
-$dark-4: #222222;
+$dark-1: #666666;
+$dark-2: #555555;
+$dark-3: #444444;
+$dark-4: #333333;
 
 $purple-1: #6b69d6;
 $purple-2: #504fa1;
@@ -23,10 +23,12 @@ $artifact: #dbcc78;
 
 // HORDE
 $horde-red-1: #8c1616; // Header Color
-$horde-red-2: #c24a3d; // Option toggle color
+$horde-red-2: #9e1d1d; // Option toggle color
 $horde-red-3: #590000; // Scroll bar toggle color
+$horde-control: #c24a3d; // Option toggle color
 
 // ALLIANCE
 $alliance-blue-1: #162c57; // Header color
-$alliance-blue-2: #455484; // Option toggle color
+$alliance-blue-2: #2b4a88; // Option toggle color
 $alliance-blue-3: #00002e; // Scroll bar toggle color
+$alliance-control: #406abd; // Option toggle color

--- a/wowup-electron/src/variables.scss
+++ b/wowup-electron/src/variables.scss
@@ -2,10 +2,10 @@ $blue-1: #315891;
 $blue-2: #24416c;
 $highlight: #01baef;
 
-$dark-1: #666666;
-$dark-2: #555555;
-$dark-3: #444444;
-$dark-4: #333333;
+$dark-1: #555555;
+$dark-2: #444444;
+$dark-3: #333333;
+$dark-4: #222222;
 
 $purple-1: #6b69d6;
 $purple-2: #504fa1;
@@ -23,10 +23,10 @@ $artifact: #dbcc78;
 
 // HORDE
 $horde-red-1: #8c1616; // Header Color
-$horde-red-2: #ff8e8e; // Option toggle color
-$horde-red-3: #ef8e8e; // Scroll bar toggle color
+$horde-red-2: #c24a3d; // Option toggle color
+$horde-red-3: #590000; // Scroll bar toggle color
 
 // ALLIANCE
 $alliance-blue-1: #162c57; // Header color
-$alliance-blue-2: #8ea4cf; // Option toggle color
-$alliance-blue-3: #7ea4cf; // Scroll bar toggle color
+$alliance-blue-2: #455484; // Option toggle color
+$alliance-blue-3: #00002e; // Scroll bar toggle color


### PR DESCRIPTION
This is a simple tweak to the theme colors to enable better visibility to the options page.

I used the standard hex code for wow alliance blue which helps it to stand out more.

--- EDIT ---

Retweaked the color pallet for both factions using complementary color pallet. I also lowered each background color hex value by 1 each so the colors display prominently.

Also added CSS override for the filter selector on My Addons.

I attempted to theme the check box and radio menu from inside the addon pup ups but trying to over ride Angular Material default values is proving a little tricky. I will come back to that.

![image](https://user-images.githubusercontent.com/1172935/99159463-64e86f80-2691-11eb-9b1a-6570dcae2b33.png)

![image](https://user-images.githubusercontent.com/1172935/99159465-6e71d780-2691-11eb-8fd2-8a06d2721902.png)

![image](https://user-images.githubusercontent.com/1172935/99159474-792c6c80-2691-11eb-8f04-f9f1e6f3d841.png)

![image](https://user-images.githubusercontent.com/1172935/99159480-80537a80-2691-11eb-9b58-66cda32a3000.png)
