### PR TITLE
Remove existing addon directories instead of only new ones added by the zip

### DIFF
--- a/wowup-electron/src/app/services/addons/addon.service.ts
+++ b/wowup-electron/src/app/services/addons/addon.service.ts
@@ -287,7 +287,7 @@ export class AddonService {
       }
 
       const unzippedDirectoryNames = await this._fileService.listDirectories(unzippedDirectory);
-      const existingDirectoryNames = addon.installedFolders.split(",");
+      const existingDirectoryNames = this.getInstalledFolders(addon);
       const addedDirectoryNames = _.difference(unzippedDirectoryNames, existingDirectoryNames);
       const removedDirectoryNames = _.difference(existingDirectoryNames, unzippedDirectoryNames);
 
@@ -390,7 +390,7 @@ export class AddonService {
   }
 
   private async backupOriginalDirectories(addon: Addon) {
-    const installedFolders = addon.installedFolders.split(",");
+    const installedFolders = this.getInstalledFolders(addon);
     const addonFolderPath = this._warcraftService.getAddonFolderPath(addon.clientType);
 
     let backupFolders = [];

--- a/wowup-electron/src/app/services/download/download.service.ts
+++ b/wowup-electron/src/app/services/download/download.service.ts
@@ -9,7 +9,7 @@ import { ElectronService } from "../electron/electron.service";
 @Injectable({
   providedIn: "root",
 })
-export class DownloadSevice {
+export class DownloadService {
   constructor(private _electronService: ElectronService) {}
 
   public downloadZipFile(


### PR DESCRIPTION
This will fix the issue when an addon removes folders, they were still kept and loaded by wow.

### Behavioral Change
In the old scenario the backups and directories removed based on the directories that were present in the ZIP file. These directories were backed up with -bak and later removed. In the new scenario the directories known by the addon are used, so it will never leave anything behind that is loaded by wow on accident.
 
Some log snippets:
```
20:51:48.720 > Ensure existing backup is deleted C:\Games\World of Warcraft\_retail_\Interface\AddOns\ElvUI_Linaori_Test-bak
20:51:48.730 > path-exists C:\Games\World of Warcraft\_retail_\Interface\AddOns\ElvUI_Linaori_Test-bak
20:51:48.737 > path-exists C:\Games\World of Warcraft\_retail_\Interface\AddOns\ElvUI_Linaori_Test
20:51:48.744 > Backing up C:\Games\World of Warcraft\_retail_\Interface\AddOns\ElvUI_Linaori_Test
20:51:48.752 > Copy File {
  destinationFilePath: 'C:\\Games\\World of Warcraft\\_retail_\\Interface\\AddOns\\ElvUI_Linaori_Test-bak',
  sourceFilePath: 'C:\\Games\\World of Warcraft\\_retail_\\Interface\\AddOns\\ElvUI_Linaori_Test',
  responseKey: '03db5cb3-9b4e-4b62-8e45-2c291564f0f3'
}
20:51:48.763 > Delete File/Dir C:\Games\World of Warcraft\_retail_\Interface\AddOns\ElvUI_Linaori_Test
20:51:51.703 > Removing backup C:\Games\World of Warcraft\_retail_\Interface\AddOns\ElvUI_Linaori_Test-bak

21:10:16.849 > Addon added new directories [ 'ElvUI_OptionsUI' ]
21:10:16.857 > Addon removed existing directories [ 'ElvUI_Linaori' ]
```