### PR TITLE
fix: filtered addon source when updating

### DIFF
--- a/wowup-electron/src/app/pages/my-addons/my-addons.component.ts
+++ b/wowup-electron/src/app/pages/my-addons/my-addons.component.ts
@@ -782,7 +782,7 @@ export class MyAddonsComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   private onAddonInstalledEvent = (evt: AddonUpdateEvent) => {
-    let listItems: AddonViewModel[] = [].concat(this.sortedListItems);
+    let listItems: AddonViewModel[] = [].concat(this._displayAddonsSrc.value);
     const listItemIdx = listItems.findIndex((li) => li.addon.id === evt.addon.id);
     const listItem = this.createAddonListItem(evt.addon);
     listItem.isInstalling = [AddonInstallState.Installing, AddonInstallState.Downloading].includes(evt.installState);


### PR DESCRIPTION
After an addon is installed, keep addon source intact even if it is currently filtered.

Before:
![video_2020-11-18 08-45-39](https://user-images.githubusercontent.com/7883662/99572352-5f3ca380-2989-11eb-88a4-f4fe17b7c8ea.gif)

After:
![video_2020-11-18 08-48-18](https://user-images.githubusercontent.com/7883662/99572376-6c599280-2989-11eb-842c-1bb770f73e24.gif)