### PR TITLE
Ensure no controls can be used during addon updates

### DIFF
--- a/wowup-electron/src/app/pages/my-addons/my-addons.component.html
+++ b/wowup-electron/src/app/pages/my-addons/my-addons.component.html
@@ -38,11 +38,10 @@
           <div class="menu-button-divider"></div>
           <button mat-flat-button color="primary" class="chip col justify-content-center"
             [matMenuTriggerFor]="updateAllMenu" [disabled]="enableControls === false || enableUpdateAll === false">
-            <mat-icon class="auto-update-icon" svgIcon="fas:caret-down">
-            </mat-icon>
+            <mat-icon svgIcon="fas:caret-down"></mat-icon>
           </button>
         </div>
-        <mat-menu #updateAllMenu="matMenu">
+        <mat-menu #updateAllMenu="matMenu" xPosition="before">
           <button mat-menu-item (click)="onUpdateAllRetailClassic()">
             {{ "PAGES.MY_ADDONS.UPDATE_ALL_CONTEXT_MENU.UPDATE_RETAIL_CLASSIC_BUTTON" | translate }}
           </button>

--- a/wowup-electron/src/app/pages/my-addons/my-addons.component.scss
+++ b/wowup-electron/src/app/pages/my-addons/my-addons.component.scss
@@ -38,15 +38,13 @@
 }
 
 .menu-button {
-  padding: 0;
   overflow: hidden;
   margin-right: 0 !important;
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
-  padding: 0 4px 0 16px;
+  padding: 0 16px;
 }
 .menu-button-divider {
-  background-color: $white-3;
   width: 1px;
   height: 36px;
 }
@@ -54,12 +52,13 @@
   margin-right: 0.5em;
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
-  padding: 0 4px;
+  padding: 0 10px;
   width: auto;
   min-width: auto;
 
   .mat-icon {
     width: 12px;
+    padding-bottom: 3px;
   }
 }
 


### PR DESCRIPTION
Hopefully fixes #468.

This PR has 2 components:
 1. all controls will be disabled when something is installing
     - update all button no longer flickers when in "backing up" state
 2. style changes for the update button after the new dropdown is introduced
     - dropdown aligned to the right instead of left
     - more padding added
     - removed the bg color of the divider to make it blend in better

### style updates
![image](https://user-images.githubusercontent.com/1754678/99735929-c5c6dc00-2ac5-11eb-8237-9bb367280a56.png)
![image](https://user-images.githubusercontent.com/1754678/99735990-e7c05e80-2ac5-11eb-9bf0-88f1c67317ad.png)

### disabled controls
![image](https://user-images.githubusercontent.com/1754678/99735841-a0d26900-2ac5-11eb-9c62-855c311cf7a8.png)
