### PR TITLE
Always try to get the TOC gameVersion values when updating

### DIFF
--- a/wowup-electron/src/app/services/addons/addon.service.ts
+++ b/wowup-electron/src/app/services/addons/addon.service.ts
@@ -337,8 +337,9 @@ export class AddonService {
       addon.installedAt = new Date();
       addon.installedFolders = unzippedDirectoryNames.join(",");
 
-      if (!addon.gameVersion) {
-        addon.gameVersion = await this.getLatestGameVersion(unzippedDirectory, unzippedDirectoryNames);
+      const gameVersion = await this.getLatestGameVersion(unzippedDirectory, unzippedDirectoryNames);
+      if (gameVersion) {
+        addon.gameVersion = gameVersion;
       }
 
       this._addonStorage.set(addon.id, addon);
@@ -414,7 +415,7 @@ export class AddonService {
       versions.push(toc.interface);
     }
 
-    return AddonUtils.getGameVersion(_.orderBy(versions)[0] || "");
+    return AddonUtils.getGameVersion(_.orderBy(versions, null, "desc")[0] || "");
   }
 
   private async backupOriginalDirectories(addon: Addon) {


### PR DESCRIPTION
Previously it would leave the existing `gameVersion` and only try to update it when it didn't exist. Sorting also seemed to ASC by default instead of DESC