### PR TITLE
Use the new "needsUpdate" check instead of just checking versions

### DIFF
--- a/wowup-electron/src/app/components/my-addons-addon-cell/my-addons-addon-cell.component.html
+++ b/wowup-electron/src/app/components/my-addons-addon-cell/my-addons-addon-cell.component.html
@@ -51,7 +51,7 @@
       </div>
       {{ listItem.addon.installedVersion }}
       <div class="update-available row"
-        *ngIf="showUpdateToVersion && listItem.addon.latestVersion !== listItem.addon.installedVersion">
+        *ngIf="showUpdateToVersion && listItem.needsUpdate">
         <mat-icon class="upgrade-icon" svgIcon="fas:play"></mat-icon>
         <div>{{ listItem.addon.latestVersion }}</div>
       </div>

--- a/wowup-electron/src/app/pages/my-addons/my-addons.component.html
+++ b/wowup-electron/src/app/pages/my-addons/my-addons.component.html
@@ -110,7 +110,7 @@
           {{ "PAGES.MY_ADDONS.TABLE.LATEST_VERSION_COLUMN_HEADER" | translate }}
         </th>
         <td mat-cell *matCellDef="let element" class="cell-padding"
-          [ngClass]="{ 'addon-update-available': element.addon.latestVersion !== element.addon.installedVersion }">
+          [ngClass]="{ 'addon-update-available': element.needsUpdate }">
           {{ element.addon.latestVersion }}
         </td>
       </ng-container>

--- a/wowup-electron/src/app/utils/addon.utils.ts
+++ b/wowup-electron/src/app/utils/addon.utils.ts
@@ -16,7 +16,7 @@ export function hasMultipleProviders(addon: Addon): boolean {
 export function needsUpdate(addon: Addon): boolean {
   return (
     addon.installedVersion !== addon.latestVersion ||
-    new Date(addon.installedAt).getTime() < new Date(addon.releasedAt).getTime()
+    new Date(addon.updatedAt).getTime() < new Date(addon.releasedAt).getTime()
   );
 }
 


### PR DESCRIPTION
This uses the `needsUpdate` check instead of manually comparing versions. This will fix any missing detection added in the future.