### PR TITLE
change the color used on the cancel button of the confirm-dialog

### DIFF
--- a/wowup-electron/src/app/components/confirm-dialog/confirm-dialog.component.html
+++ b/wowup-electron/src/app/components/confirm-dialog/confirm-dialog.component.html
@@ -4,7 +4,7 @@
 </div>
 <div mat-dialog-actions class="dialog-buttons">
   <div class="btn-wrapper">
-    <button mat-button [mat-dialog-close]="false" color="warn">
+    <button mat-button [mat-dialog-close]="false">
       {{ "DIALOGS.CONFIRM.NEGATIVE_BUTTON" | translate }}
     </button>
     <button mat-raised-button [mat-dialog-close]="true" cdkFocusInitial color="primary">

--- a/wowup-electron/src/app/components/confirm-dialog/confirm-dialog.component.html
+++ b/wowup-electron/src/app/components/confirm-dialog/confirm-dialog.component.html
@@ -4,7 +4,7 @@
 </div>
 <div mat-dialog-actions class="dialog-buttons">
   <div class="btn-wrapper">
-    <button mat-button [mat-dialog-close]="false" color="primary">
+    <button mat-button [mat-dialog-close]="false" color="warn">
       {{ "DIALOGS.CONFIRM.NEGATIVE_BUTTON" | translate }}
     </button>
     <button mat-raised-button [mat-dialog-close]="true" cdkFocusInitial color="primary">


### PR DESCRIPTION
Fixes #520 

This is my first time ever using a lot of your chosen tech stack, so extra scrutiny is warranted.  However, I wanted to see if I could offer a fix since it's marked as a good first issue.  And the change here - if you like it - turned out to be really simple.

I noticed that the color chosen for `warn` was a bright orange and I suspected that it would work across all themes, light and dark.  So this PR changes the color of the `NEGATIVE_BUTTON` in the `confirm-dialog` to "warn".

Running this locally, I tested against all of the themes and I find it to be much more readable than it was.