### PR TITLE
Fixed a possible null reference

### DIFF
--- a/wowup-electron/src/app/services/snackbar/snackbar.service.ts
+++ b/wowup-electron/src/app/services/snackbar/snackbar.service.ts
@@ -33,7 +33,7 @@ export class SnackbarService {
   }
 
   public showSnackbar(localeKey: string, config?: SnackbarConfig): MatSnackBarRef<CenteredSnackbarComponent> {
-    const message = this._translateService.instant(localeKey, config.localeArgs);
+    const message = this._translateService.instant(localeKey, config?.localeArgs);
     const data: CenteredSnackbarComponentData = {
       message,
     };


### PR DESCRIPTION
In the current beta, calling the follow code leads to an error:
```ts
// TypeError: Cannot read property 'localeArgs' of undefined
this._snackBarService.showSnackbar("APP.WOWUP_UPDATE.NOT_AVAILABLE");
```