### PR TITLE
WowUp#805 Add standard MacOS Show/Hide options to Application menu

### DIFF
--- a/wowup-electron/app-menu.ts
+++ b/wowup-electron/app-menu.ts
@@ -58,7 +58,13 @@ function createMacMenuItems(win: BrowserWindow, config?: MenuConfig): Array<Menu
   return [
     {
       label: app.name,
-      submenu: [{ label: config.quitLabel, role: "quit" }],
+      submenu: [
+        {label: 'Hide WowUp', accelerator: 'Command+H', role: 'hide'},
+        {label: 'Hide Others', accelerator: 'Command+Alt+H', role: 'hideOthers'},
+        {label: 'Show All', role: 'unhide'},
+        { type: 'separator' },
+        { label: config.quitLabel, role: "quit" }
+      ],
     },
     {
       label: config.editLabel,


### PR DESCRIPTION
Add the standard MacOS Show/Hide options to the Application menu - otherwise it's next to impossible to hide the app.

There doesn't seem to be any easy way to internationalize this - for some reason electron doesn't pull the menu item strings in from the operating system.