### PR TITLE
Fix the possibility of LatestFile to be undefined

### DIFF
--- a/wowup-electron/src/app/services/addons/addon.service.ts
+++ b/wowup-electron/src/app/services/addons/addon.service.ts
@@ -1095,7 +1095,7 @@ export class AddonService {
         addon.warningType = undefined;
 
         // Check for a new download URL
-        if (latestFile.downloadUrl && latestFile.downloadUrl !== addon.downloadUrl) {
+        if (latestFile?.downloadUrl && latestFile.downloadUrl !== addon.downloadUrl) {
           addon.downloadUrl = latestFile.downloadUrl || addon.downloadUrl;
         }
 


### PR DESCRIPTION
Fixes the error:
```
[error] Failed to sync from provider: WowUpHub TypeError: Cannot read property 'downloadUrl' of undefined
```