### PR TITLE
Fix permissions on files copied from inside the app to outside

### DIFF
--- a/wowup-electron/ipc-events.ts
+++ b/wowup-electron/ipc-events.ts
@@ -340,6 +340,7 @@ export function initializeIpcHandlers(window: BrowserWindow, userAgent: string):
     async (evt, arg: CopyFileRequest): Promise<boolean> => {
       log.info(`[FileCopy] '${arg.sourceFilePath}' -> '${arg.destinationFilePath}'`);
       await fs.copy(arg.sourceFilePath, arg.destinationFilePath);
+      await fs.chmod(arg.destinationFilePath, arg.destinationFileChmod);
       return true;
     }
   );

--- a/wowup-electron/src/app/services/files/file.service.ts
+++ b/wowup-electron/src/app/services/files/file.service.ts
@@ -82,7 +82,7 @@ export class FileService {
   /**
    * Copy a file or folder
    */
-  public async copy(sourceFilePath: string, destinationFilePath: string, destinationFileChmod: string | number = '0770'): Promise<string> {
+  public async copy(sourceFilePath: string, destinationFilePath: string, destinationFileChmod: string | number = 0o775): Promise<string> {
     const request: CopyFileRequest = {
       sourceFilePath,
       destinationFilePath,

--- a/wowup-electron/src/app/services/files/file.service.ts
+++ b/wowup-electron/src/app/services/files/file.service.ts
@@ -82,10 +82,11 @@ export class FileService {
   /**
    * Copy a file or folder
    */
-  public async copy(sourceFilePath: string, destinationFilePath: string): Promise<string> {
+  public async copy(sourceFilePath: string, destinationFilePath: string, destinationFileChmod: string | number = '0770'): Promise<string> {
     const request: CopyFileRequest = {
-      destinationFilePath,
       sourceFilePath,
+      destinationFilePath,
+      destinationFileChmod,
       responseKey: uuidv4(),
     };
 

--- a/wowup-electron/src/common/models/copy-file-request.ts
+++ b/wowup-electron/src/common/models/copy-file-request.ts
@@ -3,4 +3,5 @@ import { IpcRequest } from "./ipc-request";
 export interface CopyFileRequest extends IpcRequest {
   sourceFilePath: string;
   destinationFilePath: string;
+  destinationFileChmod: string | number;
 }


### PR DESCRIPTION
Hopefully fixes #882.

This PR will ensure the permissions of files copied from inside the app are no longer read-only after copying. Read only status seems to cause the Blizzard launcher to want to re-check all clients, start an update process and fix the file permissions (don't ask me why). The steps to reproduce this are documented in #882.

I have not been able to test this fix locally with a packaged app, and the correct behavior was already done locally because the files are on the file-system with the correct status. I can confirm however that the chmod works as intended through testing, so this _should_ fix the issue when packaged as well.