### PR TITLE
Select which addon details tab to show

### DIFF
--- a/wowup-electron/src/app/components/addon-detail/addon-detail.component.ts
+++ b/wowup-electron/src/app/components/addon-detail/addon-detail.component.ts
@@ -60,6 +60,7 @@ export class AddonDetailComponent implements OnInit, OnDestroy, AfterViewChecked
   public fetchingChangelog = true;
   public fetchingFullDescription = true;
   public selectedTabIndex = 0;
+  public defaultSelectedTabIndex = 0;
   public requiredDependencyCount = 0;
   public canShowChangelog = true;
   public hasIconUrl = false;
@@ -119,6 +120,8 @@ export class AddonDetailComponent implements OnInit, OnDestroy, AfterViewChecked
     this.canShowChangelog = this._addonService.canShowChangelog(this.getProviderName());
 
     this.selectedTabIndex = this.getSelectedTabTypeIndex(this._sessionService.getSelectedDetailsTab());
+
+    this.defaultSelectedTabIndex = this.getSelectedTabTypeIndex(this._sessionService.getDefaultSelectedDetailsTab());
 
     this.thumbnailLetter = this.getThumbnailLetter();
 
@@ -182,7 +185,9 @@ export class AddonDetailComponent implements OnInit, OnDestroy, AfterViewChecked
   }
 
   public onSelectedTabChange(evt: MatTabChangeEvent): void {
-    this._sessionService.setSelectedDetailsTab(this.getSelectedTabTypeFromIndex(evt.index));
+    if (this.defaultSelectedTabIndex === 2) {
+      this._sessionService.setSelectedDetailsTab(this.getSelectedTabTypeFromIndex(evt.index));
+    }
   }
 
   public onClickExternalId(): void {
@@ -265,6 +270,7 @@ export class AddonDetailComponent implements OnInit, OnDestroy, AfterViewChecked
   }
 
   private getSelectedTabTypeIndex(tabType: DetailsTabType): number {
+    if (tabType === "last_used_tab") return 2;
     return tabType === "description" ? 0 : 1;
   }
 

--- a/wowup-electron/src/app/components/options-app-section/options-app-section.component.html
+++ b/wowup-electron/src/app/components/options-app-section/options-app-section.component.html
@@ -197,17 +197,15 @@
     <div class="row align-items-center">
       <div class="flex-grow-1">
         <div>
-          <!-- Need to change all detail to plural => details  -->
-          {{ "PAGES.OPTIONS.APPLICATION.SET_ADDON_DETAIL_DEFAULT_TAB_LABEL" | translate }}
+          {{ "PAGES.OPTIONS.APPLICATION.SET_DETAIL_DEFAULT_TAB_LABEL" | translate }}
         </div>
-        <small class="text-2">{{ "PAGES.OPTIONS.APPLICATION.SET_ADDON_DETAIL_DEFAULT_TAB_DESCRIPTION" | translate }}</small>
+        <small class="text-2">{{ "PAGES.OPTIONS.APPLICATION.SET_DETAIL_DEFAULT_TAB_DESCRIPTION" | translate }}</small>
       </div>
       <mat-form-field class="">
-        <!-- still need to add all this to en.json -->
-        <mat-label>{{ "PAGES.OPTIONS.APPLICATION.CURRENT_DEFAULT_ADDON_DETAILS_TAB_SELECTION_LABEL" | translate }}</mat-label>
-        <mat-select [value]="currentDefaultAddonDetailsTabSelection" (selectionChange)="onCurrentDefaultDetailsTabSelectionChange($event)">
-          <mat-option *ngFor="let selection of addonDetailsTabSelections" [value]="selection.label">
-            {{ selection.label }} <!-- ??? dont know if those or the above [value] works, check en.json -->
+        <mat-label>{{ "PAGES.OPTIONS.APPLICATION.CURRENT_DEFAULT_DETAILS_TAB_SELECTION_LABEL" | translate }}</mat-label>
+        <mat-select [value]="currentDefaultDetailsTabSelection" (selectionChange)="onCurrentDefaultDetailsTabSelectionChange($event)">
+          <mat-option *ngFor="let selection of detailsTabSelections" [value]="selection.val">
+            {{ selection.label }}
           </mat-option>
         </mat-select>
       </mat-form-field>

--- a/wowup-electron/src/app/components/options-app-section/options-app-section.component.html
+++ b/wowup-electron/src/app/components/options-app-section/options-app-section.component.html
@@ -192,4 +192,26 @@
     </div>
     <div class="divider"></div>
   </div>
+  <!-- ADDON DETAIL DEFAULT TAB SELECTION -->
+  <div class="toggle">
+    <div class="row align-items-center">
+      <div class="flex-grow-1">
+        <div>
+          <!-- Need to change all detail to plural => details  -->
+          {{ "PAGES.OPTIONS.APPLICATION.SET_ADDON_DETAIL_DEFAULT_TAB_LABEL" | translate }}
+        </div>
+        <small class="text-2">{{ "PAGES.OPTIONS.APPLICATION.SET_ADDON_DETAIL_DEFAULT_TAB_DESCRIPTION" | translate }}</small>
+      </div>
+      <mat-form-field class="">
+        <!-- still need to add all this to en.json -->
+        <mat-label>{{ "PAGES.OPTIONS.APPLICATION.CURRENT_DEFAULT_ADDON_DETAILS_TAB_SELECTION_LABEL" | translate }}</mat-label>
+        <mat-select [value]="currentDefaultAddonDetailsTabSelection" (selectionChange)="onCurrentDefaultDetailsTabSelectionChange($event)">
+          <mat-option *ngFor="let selection of addonDetailsTabSelections" [value]="selection.label">
+            {{ selection.label }} <!-- ??? dont know if those or the above [value] works, check en.json -->
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+    </div>
+    <div class="divider"></div>
+  </div>
 </div>

--- a/wowup-electron/src/app/components/options-app-section/options-app-section.component.ts
+++ b/wowup-electron/src/app/components/options-app-section/options-app-section.component.ts
@@ -32,6 +32,10 @@ interface LocaleListItem {
   label: string;
 }
 
+interface TabListItem {
+  label: string;
+}
+
 @Component({
   selector: "app-options-app-section",
   templateUrl: "./options-app-section.component.html",
@@ -52,6 +56,7 @@ export class OptionsAppSectionComponent implements OnInit {
   public currentLanguage = "";
   public zoomScale = ZOOM_SCALE;
   public currentScale = 1;
+  public currentDefaultAddonDetailsTabSelection = "";
   public languages: LocaleListItem[] = [
     { localeId: "en", label: "English" },
     { localeId: "cs", label: "Čestina" },
@@ -65,6 +70,12 @@ export class OptionsAppSectionComponent implements OnInit {
     { localeId: "ru", label: "русский" },
     { localeId: "zh", label: "简体中文" },
     { localeId: "zh-TW", label: "繁體中文" },
+  ];
+
+  public addonDetailsTabSelections: TabListItem[] = [
+    { label: "Last used tab" },
+    { label: "Description" },
+    { label: "Changelog" }
   ];
 
   public themeGroups: ThemeGroup[] = [
@@ -121,6 +132,7 @@ export class OptionsAppSectionComponent implements OnInit {
     this.startMinimized = this.wowupService.startMinimized;
     this.currentLanguage = this.wowupService.currentLanguage;
     this.useSymlinkMode = this.wowupService.useSymlinkMode;
+    this.currentDefaultAddonDetailsTabSelection = this.wowupService.defaultAddonDetailsTabSelection;
 
     this.initScale().catch((e) => console.error(e));
 
@@ -308,6 +320,10 @@ export class OptionsAppSectionComponent implements OnInit {
     const newScale = evt.value;
     await this._zoomService.setZoomFactor(newScale);
     this.currentScale = newScale;
+  };
+
+  public onCurrentDefaultDetailsTabSelectionChange = (evt: MatSelectChange): void => {
+    this.wowupService.defaultAddonDetailsTabSelection = evt.value;
   };
 
   private async updateScale() {

--- a/wowup-electron/src/app/components/options-app-section/options-app-section.component.ts
+++ b/wowup-electron/src/app/components/options-app-section/options-app-section.component.ts
@@ -33,6 +33,7 @@ interface LocaleListItem {
 }
 
 interface TabListItem {
+  val: string,
   label: string;
 }
 
@@ -56,7 +57,8 @@ export class OptionsAppSectionComponent implements OnInit {
   public currentLanguage = "";
   public zoomScale = ZOOM_SCALE;
   public currentScale = 1;
-  public currentDefaultAddonDetailsTabSelection = "";
+  public currentDefaultDetailsTabSelection = "";
+  public currentDetailsTabSelection = "";
   public languages: LocaleListItem[] = [
     { localeId: "en", label: "English" },
     { localeId: "cs", label: "Čestina" },
@@ -72,10 +74,10 @@ export class OptionsAppSectionComponent implements OnInit {
     { localeId: "zh-TW", label: "繁體中文" },
   ];
 
-  public addonDetailsTabSelections: TabListItem[] = [
-    { label: "Last used tab" },
-    { label: "Description" },
-    { label: "Changelog" }
+  public detailsTabSelections: TabListItem[] = [
+    { val: "last_used_tab", label: "Last used tab" },
+    { val: "description", label: "Description" },
+    { val: "changelog", label: "Changelog" }
   ];
 
   public themeGroups: ThemeGroup[] = [
@@ -132,7 +134,7 @@ export class OptionsAppSectionComponent implements OnInit {
     this.startMinimized = this.wowupService.startMinimized;
     this.currentLanguage = this.wowupService.currentLanguage;
     this.useSymlinkMode = this.wowupService.useSymlinkMode;
-    this.currentDefaultAddonDetailsTabSelection = this.wowupService.defaultAddonDetailsTabSelection;
+    this.currentDefaultDetailsTabSelection = this.sessionService.getDefaultSelectedDetailsTab();
 
     this.initScale().catch((e) => console.error(e));
 
@@ -323,7 +325,11 @@ export class OptionsAppSectionComponent implements OnInit {
   };
 
   public onCurrentDefaultDetailsTabSelectionChange = (evt: MatSelectChange): void => {
-    this.wowupService.defaultAddonDetailsTabSelection = evt.value;
+    this.sessionService.setDefaultSelectedDetailsTab(evt.value);
+    if (evt.value != "last_used_tab")
+    {
+      this.sessionService.setSelectedDetailsTab(evt.value);
+    }
   };
 
   private async updateScale() {

--- a/wowup-electron/src/app/services/session/session.service.ts
+++ b/wowup-electron/src/app/services/session/session.service.ts
@@ -4,7 +4,7 @@ import { filter } from "rxjs/operators";
 
 import { Injectable } from "@angular/core";
 
-import { SELECTED_DETAILS_TAB_KEY } from "../../../common/constants";
+import { SELECTED_DETAILS_TAB_KEY, DEFAULT_SELECTED_DETAILS_TAB_KEY } from "../../../common/constants";
 import { WowInstallation } from "../../models/wowup/wow-installation";
 import { PreferenceStorageService } from "../storage/preference-storage.service";
 import { WarcraftInstallationService } from "../warcraft/warcraft-installation.service";
@@ -26,6 +26,7 @@ export class SessionService {
   private readonly _getAddonsColumnsSrc = new Subject<ColumnState>();
 
   private _selectedDetailTabType: DetailsTabType;
+  private _defaultSelectedDetailTabType: DetailsTabType;
 
   public readonly selectedWowInstallation$ = this._selectedWowInstallationSrc.asObservable();
   public readonly statusText$ = this._statusTextSrc.asObservable();
@@ -43,6 +44,8 @@ export class SessionService {
   ) {
     this._selectedDetailTabType =
       this._preferenceStorageService.getObject<DetailsTabType>(SELECTED_DETAILS_TAB_KEY) || "description";
+    
+    this._defaultSelectedDetailTabType = this._preferenceStorageService.getObject<DetailsTabType>(DEFAULT_SELECTED_DETAILS_TAB_KEY) || "description";
 
     this._warcraftInstallationService.wowInstallations$
       .pipe(filter((installations) => installations.length > 0))
@@ -64,6 +67,15 @@ export class SessionService {
   public setSelectedDetailsTab(tabType: DetailsTabType): void {
     this._selectedDetailTabType = tabType;
     this._preferenceStorageService.set(SELECTED_DETAILS_TAB_KEY, tabType);
+  }
+
+  public getDefaultSelectedDetailsTab(): DetailsTabType {
+    return this._defaultSelectedDetailTabType;
+  }
+
+  public setDefaultSelectedDetailsTab(tabType: DetailsTabType): void {
+    this._defaultSelectedDetailTabType = tabType;
+    this._preferenceStorageService.set(DEFAULT_SELECTED_DETAILS_TAB_KEY, tabType);
   }
 
   public onWowInstallationsChange(wowInstallations: WowInstallation[]): void {

--- a/wowup-electron/src/app/services/wowup/wowup.service.ts
+++ b/wowup-electron/src/app/services/wowup/wowup.service.ts
@@ -20,6 +20,8 @@ import {
   APP_UPDATE_START_DOWNLOAD,
   COLLAPSE_TO_TRAY_PREFERENCE_KEY,
   CURRENT_THEME_KEY,
+  DEFAULT_ADDON_DETAILS_TAB_SELECTION_KEY,
+  DEFAULT_ADDON_DETAILS_TAB_SELECTION,
   DEFAULT_AUTO_UPDATE_PREFERENCE_KEY_SUFFIX,
   DEFAULT_CHANNEL_PREFERENCE_KEY_SUFFIX,
   DEFAULT_LIGHT_THEME,
@@ -395,6 +397,16 @@ export class WowUpService {
       default:
         return "assets/images/wowup-white-1.png";
     }
+  }
+
+  public get defaultAddonDetailsTabSelection(): string {
+    return this._preferenceStorageService.get(DEFAULT_ADDON_DETAILS_TAB_SELECTION_KEY) || DEFAULT_ADDON_DETAILS_TAB_SELECTION;
+  }
+
+  public set defaultAddonDetailsTabSelection(value: string) {
+    const key = DEFAULT_ADDON_DETAILS_TAB_SELECTION_KEY;
+    this._preferenceStorageService.set(key, value);
+    this._preferenceChangeSrc.next({ key, value: value.toString() });
   }
 
   private setDefaultPreference(key: string, defaultValue: any) {

--- a/wowup-electron/src/app/services/wowup/wowup.service.ts
+++ b/wowup-electron/src/app/services/wowup/wowup.service.ts
@@ -20,8 +20,8 @@ import {
   APP_UPDATE_START_DOWNLOAD,
   COLLAPSE_TO_TRAY_PREFERENCE_KEY,
   CURRENT_THEME_KEY,
-  DEFAULT_ADDON_DETAILS_TAB_SELECTION_KEY,
-  DEFAULT_ADDON_DETAILS_TAB_SELECTION,
+  DEFAULT_SELECTED_DETAILS_TAB_KEY,
+  DEFAULT_SELECTED_DETAILS_TAB,
   DEFAULT_AUTO_UPDATE_PREFERENCE_KEY_SUFFIX,
   DEFAULT_CHANNEL_PREFERENCE_KEY_SUFFIX,
   DEFAULT_LIGHT_THEME,
@@ -400,11 +400,11 @@ export class WowUpService {
   }
 
   public get defaultAddonDetailsTabSelection(): string {
-    return this._preferenceStorageService.get(DEFAULT_ADDON_DETAILS_TAB_SELECTION_KEY) || DEFAULT_ADDON_DETAILS_TAB_SELECTION;
+    return this._preferenceStorageService.get(DEFAULT_SELECTED_DETAILS_TAB_KEY) || DEFAULT_SELECTED_DETAILS_TAB;
   }
 
   public set defaultAddonDetailsTabSelection(value: string) {
-    const key = DEFAULT_ADDON_DETAILS_TAB_SELECTION_KEY;
+    const key = DEFAULT_SELECTED_DETAILS_TAB_KEY;
     this._preferenceStorageService.set(key, value);
     this._preferenceChangeSrc.next({ key, value: value.toString() });
   }

--- a/wowup-electron/src/assets/i18n/en.json
+++ b/wowup-electron/src/assets/i18n/en.json
@@ -391,8 +391,8 @@
         "TITLE": "Addons"
       },
       "APPLICATION": {
+        "CURRENT_DEFAULT_DETAILS_TAB_SELECTION_LABEL": "Current default tab selection",
         "CURRENT_LANGUAGE_LABEL": "Current Language",
-        "CURRENT_DEFAULT_ADDON_DETAILS_TAB_SELECTION_LABEL": "Current default tab selection",
         "CURSE_PROTOCOL_DESCRIPTION": "When downloading addons from the CurseForge website, WowUp will handle the install",
         "CURSE_PROTOCOL_LABEL": "Handle CurseForge download links",
         "ENABLE_SYSTEM_NOTIFICATIONS_DESCRIPTION": "Enable various system notification popups, such as auto updated addons.",
@@ -404,8 +404,8 @@
         "PROTOCOL_LABEL": "Enable the wowup:// URI protocol",
         "SCALE_DESCRIPTION": "Change zoom factor for entire app.",
         "SCALE_LABEL": "Scale",
-        "SET_ADDON_DETAIL_DEFAULT_TAB_DESCRIPTION": "When clicking on addons, choose which tab to show",
-        "SET_ADDON_DETAIL_DEFAULT_TAB_LABEL": "Set default addon detail tab",
+        "SET_DETAIL_DEFAULT_TAB_DESCRIPTION": "When clicking on addons, choose which tab to show",
+        "SET_DETAIL_DEFAULT_TAB_LABEL": "Set default addon detail tab",
         "SET_LANGUAGE_CONFIRMATION_DESCRIPTION": "Changing the default language requires the application to restart.",
         "SET_LANGUAGE_CONFIRMATION_LABEL": "Setting a new default language",
         "SET_LANGUAGE_DESCRIPTION": "Select a language to change to",

--- a/wowup-electron/src/assets/i18n/en.json
+++ b/wowup-electron/src/assets/i18n/en.json
@@ -392,6 +392,7 @@
       },
       "APPLICATION": {
         "CURRENT_LANGUAGE_LABEL": "Current Language",
+        "CURRENT_DEFAULT_ADDON_DETAILS_TAB_SELECTION_LABEL": "Current default tab selection",
         "CURSE_PROTOCOL_DESCRIPTION": "When downloading addons from the CurseForge website, WowUp will handle the install",
         "CURSE_PROTOCOL_LABEL": "Handle CurseForge download links",
         "ENABLE_SYSTEM_NOTIFICATIONS_DESCRIPTION": "Enable various system notification popups, such as auto updated addons.",
@@ -403,6 +404,8 @@
         "PROTOCOL_LABEL": "Enable the wowup:// URI protocol",
         "SCALE_DESCRIPTION": "Change zoom factor for entire app.",
         "SCALE_LABEL": "Scale",
+        "SET_ADDON_DETAIL_DEFAULT_TAB_DESCRIPTION": "When clicking on addons, choose which tab to show",
+        "SET_ADDON_DETAIL_DEFAULT_TAB_LABEL": "Set default addon detail tab",
         "SET_LANGUAGE_CONFIRMATION_DESCRIPTION": "Changing the default language requires the application to restart.",
         "SET_LANGUAGE_CONFIRMATION_LABEL": "Setting a new default language",
         "SET_LANGUAGE_DESCRIPTION": "Select a language to change to",

--- a/wowup-electron/src/common/constants.ts
+++ b/wowup-electron/src/common/constants.ts
@@ -105,6 +105,8 @@ export const ZOOM_FACTOR_KEY = "zoom_factor";
 export const SELECTED_DETAILS_TAB_KEY = "selected_details_tab";
 export const ADDON_MIGRATION_VERSION_KEY = "addon_migration_version";
 export const UPDATE_NOTES_POPUP_VERSION_KEY = "update_notes_popup_version";
+export const DEFAULT_ADDON_DETAILS_TAB_SELECTION_KEY = "default_addon_details_tab_selection";
+export const DEFAULT_ADDON_DETAILS_TAB_SELECTION = "last_used";
 
 // APP UPDATER
 export const APP_UPDATE_ERROR = "app-update-error";

--- a/wowup-electron/src/common/constants.ts
+++ b/wowup-electron/src/common/constants.ts
@@ -105,8 +105,8 @@ export const ZOOM_FACTOR_KEY = "zoom_factor";
 export const SELECTED_DETAILS_TAB_KEY = "selected_details_tab";
 export const ADDON_MIGRATION_VERSION_KEY = "addon_migration_version";
 export const UPDATE_NOTES_POPUP_VERSION_KEY = "update_notes_popup_version";
-export const DEFAULT_ADDON_DETAILS_TAB_SELECTION_KEY = "default_addon_details_tab_selection";
-export const DEFAULT_ADDON_DETAILS_TAB_SELECTION = "last_used";
+export const DEFAULT_SELECTED_DETAILS_TAB_KEY = "default_details_tab_selection";
+export const DEFAULT_SELECTED_DETAILS_TAB = "last_used";
 
 // APP UPDATER
 export const APP_UPDATE_ERROR = "app-update-error";

--- a/wowup-electron/src/typings.d.ts
+++ b/wowup-electron/src/typings.d.ts
@@ -8,5 +8,5 @@ interface Window {
   require: any;
 }
 
-declare type DetailsTabType = "description" | "changelog";
+declare type DetailsTabType = "description" | "changelog" | "last_used_tab";
 declare type AddonIgnoreReason = "git_repo" | "missing_dependency" | "unknown";


### PR DESCRIPTION
Intended to solve #789. 

Adds a new option to application settings to allow the user to choose where `Description`, `Changelog`, or the last used tab is shown when expanding an addon's details. This new "default tab selection" is stored in persistent storage and tracked in the application's session service.