### PR TITLE
Allow asset files to end with -bcc.zip

### DIFF
--- a/wowup-electron/src/app/addon-providers/github-addon-provider.ts
+++ b/wowup-electron/src/app/addon-providers/github-addon-provider.ts
@@ -277,7 +277,7 @@ export class GitHubAddonProvider extends AddonProvider {
   }
 
   private isBurningCrusadeAsset(asset: GitHubAsset): boolean {
-    return asset.name.toLowerCase().endsWith("-bc.zip");
+    return asset.name.toLowerCase().match(/-bc(c)?\.zip$/);
   }
 
   private getAddonName(addonId: string): string {


### PR DESCRIPTION
Many addons provider gives `-bcc.zip` files as "**B**urning **C**rusade **C**lassic" release on github. This manages all the cases.

![image](https://user-images.githubusercontent.com/5599375/119990690-eddd4d80-bfc8-11eb-92ea-5c0a32f6a715.png)
