### PR TITLE
Updated the IPC asset path to match the new one

### DIFF
--- a/wowup-electron/app/ipc-events.ts
+++ b/wowup-electron/app/ipc-events.ts
@@ -154,7 +154,7 @@ export function initializeIpcHandlers(window: BrowserWindow, userAgent: string):
   });
 
   handle(IPC_GET_ASSET_FILE_PATH, (evt, fileName: string) => {
-    return path.join(__dirname, "assets", fileName);
+    return path.join(__dirname, ".." , "assets", fileName);
   });
 
   handle(IPC_CREATE_DIRECTORY_CHANNEL, async (evt, directoryPath: string): Promise<boolean> => {


### PR DESCRIPTION
This will fix the issue for the wowup addon not updating because the files can't be located internally