### PR TITLE
Implement #1098

### DIFF
--- a/wowup-electron/src/assets/i18n/cs.json
+++ b/wowup-electron/src/assets/i18n/cs.json
@@ -175,11 +175,11 @@
     },
     "CLIENT_TYPES": {
       "BETA": "Beta",
-      "CLASSIC": "Classic",
+      "CLASSIC": "Classic TBC",
       "CLASSICBETA": "Classic Beta",
-      "CLASSICERA": "Classic Era",
-      "CLASSICERAPTR": "Classic Era PTR",
-      "CLASSICPTR": "Classic PTR",
+      "CLASSICERA": "Classic Vanilla",
+      "CLASSICERAPTR": "Classic SoM PTR",
+      "CLASSICPTR": "Classic TBC PTR",
       "RETAIL": "Retail",
       "RETAILPTR": "Retail PTR"
     },

--- a/wowup-electron/src/assets/i18n/de.json
+++ b/wowup-electron/src/assets/i18n/de.json
@@ -175,11 +175,11 @@
     },
     "CLIENT_TYPES": {
       "BETA": "Beta",
-      "CLASSIC": "Classic",
+      "CLASSIC": "Classic TBC",
       "CLASSICBETA": "Classic Beta",
-      "CLASSICERA": "Classic Era",
-      "CLASSICERAPTR": "Classic Era PTR",
-      "CLASSICPTR": "Classic PTR",
+      "CLASSICERA": "Classic Vanilla",
+      "CLASSICERAPTR": "Classic SoM PTR",
+      "CLASSICPTR": "Classic TBC PTR",
       "RETAIL": "Retail",
       "RETAILPTR": "Retail PTR"
     },

--- a/wowup-electron/src/assets/i18n/en.json
+++ b/wowup-electron/src/assets/i18n/en.json
@@ -175,11 +175,11 @@
     },
     "CLIENT_TYPES": {
       "BETA": "Beta",
-      "CLASSIC": "Classic",
+      "CLASSIC": "Classic TBC",
       "CLASSICBETA": "Classic Beta",
-      "CLASSICERA": "Classic Era",
-      "CLASSICERAPTR": "Classic Era PTR",
-      "CLASSICPTR": "Classic PTR",
+      "CLASSICERA": "Classic Vanilla",
+      "CLASSICERAPTR": "Classic SoM PTR",
+      "CLASSICPTR": "Classic TBC PTR",
       "RETAIL": "Retail",
       "RETAILPTR": "Retail PTR"
     },

--- a/wowup-electron/src/assets/i18n/es.json
+++ b/wowup-electron/src/assets/i18n/es.json
@@ -175,11 +175,11 @@
     },
     "CLIENT_TYPES": {
       "BETA": "Beta",
-      "CLASSIC": "Classic",
+      "CLASSIC": "Classic TBC",
       "CLASSICBETA": "Beta Classic",
-      "CLASSICERA": "Classic Era",
-      "CLASSICERAPTR": "RPP Classic Era",
-      "CLASSICPTR": "RPP Classic",
+      "CLASSICERA": "Classic Vanilla",
+      "CLASSICERAPTR": "RPP Classic SoM",
+      "CLASSICPTR": "RPP Classic TBC",
       "RETAIL": "Retail",
       "RETAILPTR": "RPP Retail"
     },

--- a/wowup-electron/src/assets/i18n/fr.json
+++ b/wowup-electron/src/assets/i18n/fr.json
@@ -175,11 +175,11 @@
     },
     "CLIENT_TYPES": {
       "BETA": "Beta",
-      "CLASSIC": "Classic",
+      "CLASSIC": "Classic TBC",
       "CLASSICBETA": "Beta Classic",
-      "CLASSICERA": "Classic Era",
-      "CLASSICERAPTR": "Classic Era PTR",
-      "CLASSICPTR": "PTR Classic",
+      "CLASSICERA": "Classic Vanilla",
+      "CLASSICERAPTR": "PTR Classic SoM",
+      "CLASSICPTR": "PTR Classic TBC",
       "RETAIL": "Retail",
       "RETAILPTR": "PTR Retail"
     },

--- a/wowup-electron/src/assets/i18n/it.json
+++ b/wowup-electron/src/assets/i18n/it.json
@@ -175,11 +175,11 @@
     },
     "CLIENT_TYPES": {
       "BETA": "Beta",
-      "CLASSIC": "Classic",
+      "CLASSIC": "Classic TBC",
       "CLASSICBETA": "Classic Beta",
-      "CLASSICERA": "Classic Era",
-      "CLASSICERAPTR": "Classic Era PTR",
-      "CLASSICPTR": "Classic PTR",
+      "CLASSICERA": "Classic Vanilla",
+      "CLASSICERAPTR": "Classic SoM PTR",
+      "CLASSICPTR": "Classic TBC PTR",
       "RETAIL": "Retail",
       "RETAILPTR": "Retail PTR"
     },

--- a/wowup-electron/src/assets/i18n/ko.json
+++ b/wowup-electron/src/assets/i18n/ko.json
@@ -175,11 +175,11 @@
     },
     "CLIENT_TYPES": {
       "BETA": "베타",
-      "CLASSIC": "클래식",
+      "CLASSIC": "불타는 성전",
       "CLASSICBETA": "클래식 베타",
-      "CLASSICERA": "Classic Era",
-      "CLASSICERAPTR": "Classic Era PTR",
-      "CLASSICPTR": "클래식 PTR",
+      "CLASSICERA": "Classic Vanilla",
+      "CLASSICERAPTR": "Classic SoM PTR",
+      "CLASSICPTR": "불타는 성전 PTR",
       "RETAIL": "리테일",
       "RETAILPTR": "리테일 PTR"
     },

--- a/wowup-electron/src/assets/i18n/nb.json
+++ b/wowup-electron/src/assets/i18n/nb.json
@@ -175,11 +175,11 @@
     },
     "CLIENT_TYPES": {
       "BETA": "Beta",
-      "CLASSIC": "Classic",
+      "CLASSIC": "Classic TBC",
       "CLASSICBETA": "Classic Beta",
-      "CLASSICERA": "Classic Era",
-      "CLASSICERAPTR": "Classic Era PTR",
-      "CLASSICPTR": "Classic PTR",
+      "CLASSICERA": "Classic Vanilla",
+      "CLASSICERAPTR": "Classic SoM PTR",
+      "CLASSICPTR": "Classic TBC PTR",
       "RETAIL": "Retail",
       "RETAILPTR": "Retail PTR"
     },

--- a/wowup-electron/src/assets/i18n/pl.json
+++ b/wowup-electron/src/assets/i18n/pl.json
@@ -175,11 +175,11 @@
     },
     "CLIENT_TYPES": {
       "BETA": "Beta",
-      "CLASSIC": "Classic",
+      "CLASSIC": "Classic TBC",
       "CLASSICBETA": "Classic Beta",
-      "CLASSICERA": "Classic Era",
-      "CLASSICERAPTR": "Classic Era PTR",
-      "CLASSICPTR": "Classic PTR",
+      "CLASSICERA": "Classic Vanilla",
+      "CLASSICERAPTR": "Classic SoM PTR",
+      "CLASSICPTR": "Classic TBC PTR",
       "RETAIL": "Retail",
       "RETAILPTR": "Retail PTR"
     },

--- a/wowup-electron/src/assets/i18n/pt.json
+++ b/wowup-electron/src/assets/i18n/pt.json
@@ -175,11 +175,11 @@
     },
     "CLIENT_TYPES": {
       "BETA": "Beta",
-      "CLASSIC": "Classic",
+      "CLASSIC": "Classic TBC",
       "CLASSICBETA": "Classic Beta",
-      "CLASSICERA": "Classic Era",
-      "CLASSICERAPTR": "Classic Era PTR",
-      "CLASSICPTR": "Classic PTR",
+      "CLASSICERA": "Classic Vanilla",
+      "CLASSICERAPTR": "Classic SoM PTR",
+      "CLASSICPTR": "Classic TBC PTR",
       "RETAIL": "Retail",
       "RETAILPTR": "Retail PTR"
     },

--- a/wowup-electron/src/common/warcraft/wow-installation.ts
+++ b/wowup-electron/src/common/warcraft/wow-installation.ts
@@ -5,7 +5,7 @@ export interface WowInstallation {
   id: string;
   clientType: WowClientType;
   location: string;
-  label: string;
+  label: string | null;
   selected: boolean;
   defaultAddonChannelType: AddonChannelType;
   defaultAutoUpdate: boolean;


### PR DESCRIPTION
Implemented by:
* Do not set `installation.label` when the first client of each type was added.
* Fallback to default label when `installation.label` is null or empty string.

By implementing this, the client names will also change when the app language changes.

For existing clients:
* Do not change. One can remove the names manually in “Options > Clients”.

For further maintenance:
* We can incidentally change the translation files when introducing new client type. (i.e. Set `CLIENT_TYPES.CLASSIC` to “Classic WotLK” when adding `CLIENT_TYPES.CLASSIC_BCC_ERA` or whatever.)

Translations:
* Need help on `ru`. @Medoke 
* `zh` have been already set in 8aa8557 for the same reason of #1098.