### PR TITLE
Issue #789 : Add an option to preserve last opened tab in detail modal

### DIFF
--- a/wowup-electron/src/app/components/addons/addon-detail/addon-detail.component.html
+++ b/wowup-electron/src/app/components/addons/addon-detail/addon-detail.component.html
@@ -55,7 +55,7 @@
   <!-- TABS -->
   <mat-tab-group
     #tabs
-    *ngIf="isUnknownProvider === false"
+    *ngIf="selectedTabIndex!=undefined && isUnknownProvider === false"
     class="scroller"
     [selectedIndex]="selectedTabIndex"
     (selectedTabChange)="onSelectedTabChange($event)"

--- a/wowup-electron/src/app/components/addons/addon-detail/addon-detail.component.ts
+++ b/wowup-electron/src/app/components/addons/addon-detail/addon-detail.component.ts
@@ -183,7 +183,7 @@ export class AddonDetailComponent implements OnInit, OnDestroy, AfterViewChecked
 
     this.gallery.ref().load(this.previewItems);
 
-    this.selectInitialTab();
+    this.selectInitialTab().catch(console.error);
   }
 
   public ngAfterViewInit(): void {}

--- a/wowup-electron/src/app/components/addons/addon-detail/addon-detail.component.ts
+++ b/wowup-electron/src/app/components/addons/addon-detail/addon-detail.component.ts
@@ -34,6 +34,7 @@ import { formatDynamicLinks } from "../../../utils/dom.utils";
 import * as SearchResult from "../../../utils/search-result.utils";
 import { AddonUiService } from "../../../services/addons/addon-ui.service";
 import { AddonProviderFactory } from "../../../services/addons/addon.provider.factory";
+import { WowUpService } from "../../../services/wowup/wowup.service";
 
 export interface AddonDetailModel {
   listItem?: AddonViewModel;
@@ -62,7 +63,7 @@ export class AddonDetailComponent implements OnInit, OnDestroy, AfterViewChecked
   public readonly description$ = this._descriptionSrc.asObservable();
   public fetchingChangelog = true;
   public fetchingFullDescription = true;
-  public selectedTabIndex = 0;
+  public selectedTabIndex;
   public requiredDependencyCount = 0;
   public canShowChangelog = true;
   public hasIconUrl = false;
@@ -100,6 +101,7 @@ export class AddonDetailComponent implements OnInit, OnDestroy, AfterViewChecked
     private _sessionService: SessionService,
     private _linkService: LinkService,
     private _addonUiService: AddonUiService,
+    private _wowupService: WowUpService,
     public gallery: Gallery
   ) {
     this._dependencies = this.getDependencies();
@@ -124,8 +126,6 @@ export class AddonDetailComponent implements OnInit, OnDestroy, AfterViewChecked
 
   public ngOnInit(): void {
     this.canShowChangelog = this._addonProviderService.canShowChangelog(this.getProviderName());
-
-    this.selectedTabIndex = this.getSelectedTabTypeIndex(this._sessionService.getSelectedDetailsTab());
 
     this.thumbnailLetter = this.getThumbnailLetter();
 
@@ -182,6 +182,8 @@ export class AddonDetailComponent implements OnInit, OnDestroy, AfterViewChecked
     });
 
     this.gallery.ref().load(this.previewItems);
+
+    this.selectInitialTab();
   }
 
   public ngAfterViewInit(): void {}
@@ -259,11 +261,29 @@ export class AddonDetailComponent implements OnInit, OnDestroy, AfterViewChecked
   }
 
   private getSelectedTabTypeFromIndex(index: number): DetailsTabType {
-    return index === 0 ? "description" : "changelog";
+    switch (index) {
+      case 0:
+        return "description";
+      case 1:
+        return "changelog";
+      case 2:
+        return "previews";
+      default:
+        return "description";
+    }
   }
 
   private getSelectedTabTypeIndex(tabType: DetailsTabType): number {
-    return tabType === "description" ? 0 : 1;
+    switch (tabType) {
+      case "description":
+        return 0;
+      case "changelog":
+        return 1;
+      case "previews":
+        return this.previewItems.length === 0 ? 0 : 2;
+      default:
+        return 0;
+    }
   }
 
   private getThumbnailLetter(): string {
@@ -414,5 +434,13 @@ export class AddonDetailComponent implements OnInit, OnDestroy, AfterViewChecked
     }
 
     console.warn("Invalid list item addon when verifying if installed");
+  }
+
+  private async selectInitialTab(): Promise<void> {
+    const shouldUseLastTab = await this._wowupService.getKeepLastAddonDetailTab();
+    this.selectedTabIndex = shouldUseLastTab
+      ? this.getSelectedTabTypeIndex(this._sessionService.getSelectedDetailsTab())
+      : 0;
+    this._cdRef.detectChanges();
   }
 }

--- a/wowup-electron/src/app/components/options/options-app-section/options-app-section.component.html
+++ b/wowup-electron/src/app/components/options/options-app-section/options-app-section.component.html
@@ -232,4 +232,21 @@
     </div>
     <div class="divider"></div>
   </div>
+  <!-- KEEP LAST OPENED TAB -->
+  <div class="toggle">
+    <div class="row align-items-center">
+      <div class="flex-grow-1">
+        <div>
+          {{ "PAGES.OPTIONS.APPLICATION.KEEP_LAST_OPENED_TAB_LABEL" | translate }}
+        </div>
+        <small class="text-2">{{ "PAGES.OPTIONS.APPLICATION.KEEP_LAST_OPENED_TAB_DESCRIPTION" | translate }}</small>
+      </div>
+      <mat-slide-toggle
+        [checked]="keepAddonDetailTab$ | async"
+        (change)="onKeepAddonDetailTabChange($event)"
+      >
+      </mat-slide-toggle>
+    </div>
+    <div class="divider"></div>
+  </div>
 </div>

--- a/wowup-electron/src/app/components/options/options-app-section/options-app-section.component.spec.ts
+++ b/wowup-electron/src/app/components/options/options-app-section/options-app-section.component.spec.ts
@@ -72,6 +72,7 @@ describe("OptionsAppSectionComponent", () => {
       getWowUpReleaseChannel: () => Promise.resolve(false),
       getStartWithSystem: () => Promise.resolve(false),
       getStartMinimized: () => Promise.resolve(false),
+      getKeepLastAddonDetailTab: () => Promise.resolve(false),
     });
 
     await TestBed.configureTestingModule({

--- a/wowup-electron/src/app/components/options/options-app-section/options-app-section.component.ts
+++ b/wowup-electron/src/app/components/options/options-app-section/options-app-section.component.ts
@@ -119,6 +119,7 @@ export class OptionsAppSectionComponent implements OnInit {
   public startWithSystem$ = new BehaviorSubject(false);
   public startMinimized$ = new BehaviorSubject(false);
   public currentReleaseChannel$ = new BehaviorSubject(WowUpReleaseChannelType.Stable);
+  public keepAddonDetailTab$ = new BehaviorSubject(false);
 
   public constructor(
     private _analyticsService: AnalyticsService,
@@ -219,6 +220,13 @@ export class OptionsAppSectionComponent implements OnInit {
       })
       .catch(console.error);
 
+    this.wowupService
+      .getKeepLastAddonDetailTab()
+      .then((enabled) => {
+        this.keepAddonDetailTab$.next(enabled);
+      })
+      .catch(console.error);
+
     this.initScale().catch((e) => console.error(e));
 
     this._zoomService.zoomFactor$.subscribe((zoomFactor) => {
@@ -280,6 +288,11 @@ export class OptionsAppSectionComponent implements OnInit {
   public onStartMinimizedChange = async (evt: MatSlideToggleChange): Promise<void> => {
     await this.wowupService.setStartMinimized(evt.checked);
     this.startMinimized$.next(evt.checked);
+  };
+
+  public onKeepAddonDetailTabChange = async (evt: MatSlideToggleChange): Promise<void> => {
+    await this.wowupService.setKeepLastAddonDetailTab(evt.checked);
+    this.keepAddonDetailTab$.next(evt.checked);
   };
 
   public onProtocolHandlerChange = (evt: MatSlideToggleChange, protocol: string): void => {

--- a/wowup-electron/src/app/services/wowup/wowup.service.ts
+++ b/wowup-electron/src/app/services/wowup/wowup.service.ts
@@ -23,6 +23,7 @@ import {
   IPC_APP_INSTALL_UPDATE,
   IPC_GET_APP_VERSION,
   IPC_UPDATE_APP_BADGE,
+  KEEP_ADDON_DETAIL_TAB_PREFERENCE_KEY,
   MY_ADDONS_HIDDEN_COLUMNS_KEY,
   MY_ADDONS_SORT_ORDER,
   SELECTED_LANGUAGE_PREFERENCE_KEY,
@@ -211,6 +212,17 @@ export class WowUpService {
     } catch (e) {
       console.error(e);
     }
+  }
+
+  public async getKeepLastAddonDetailTab(): Promise<boolean> {
+    const preference = await this._preferenceStorageService.getAsync(KEEP_ADDON_DETAIL_TAB_PREFERENCE_KEY);
+    return preference === "true";
+  }
+
+  public async setKeepLastAddonDetailTab(value: boolean): Promise<void> {
+    const key = KEEP_ADDON_DETAIL_TAB_PREFERENCE_KEY;
+    await this._preferenceStorageService.setAsync(key, value);
+    this._preferenceChangeSrc.next({ key, value: value.toString() });
   }
 
   public async getAddonProviderStates(): Promise<AddonProviderState[]> {

--- a/wowup-electron/src/assets/i18n/cs.json
+++ b/wowup-electron/src/assets/i18n/cs.json
@@ -532,7 +532,9 @@
         "USE_SYMLINK_SUPPORT": "Enable Symlink Support",
         "USE_SYMLINK_SUPPORT_CONFIRMATION_DESCRIPTION": "Enabling symlink support will allow WowUp to recognize symlinks when performing a re-scan. Warning: If you do not know what a symlink is, you do not need this. When updating symlinks will currently be replaced with an actual folder and the link lost.",
         "USE_SYMLINK_SUPPORT_CONFIRMATION_LABEL": "Enable symlink support?",
-        "USE_SYMLINK_SUPPORT_DESCRIPTION": "Allow WowUp to scan symlink folders in your addon folder. Warning: they will be replaced when updating/installing."
+        "USE_SYMLINK_SUPPORT_DESCRIPTION": "Allow WowUp to scan symlink folders in your addon folder. Warning: they will be replaced when updating/installing.",
+        "KEEP_LAST_OPENED_TAB_LABEL": "Keep last opened tab",
+        "KEEP_LAST_OPENED_TAB_DESCRIPTION": "When opening an addon detail page, automatically select the last opened tab"
       },
       "DEBUG": {
         "CONFIG_FILES_BUTTON": "Show Config Files",

--- a/wowup-electron/src/assets/i18n/de.json
+++ b/wowup-electron/src/assets/i18n/de.json
@@ -532,7 +532,9 @@
         "USE_SYMLINK_SUPPORT": "Symlink-Unterstützung aktivieren",
         "USE_SYMLINK_SUPPORT_CONFIRMATION_DESCRIPTION": "Durch das Aktivieren der Symlink-Unterstützung kann WowUp Symlinks erkennen, wenn ein erneuter Scan durchgeführt wird. Warnung: Wenn Du nicht weißt, was ein Symlink ist, brauchst Du dies nicht. Beim Aktualisieren werden Symlinks derzeit durch einen tatsächlichen Ordner ersetzt und der Link geht verloren.",
         "USE_SYMLINK_SUPPORT_CONFIRMATION_LABEL": "Symlink-Unterstützung aktivieren?",
-        "USE_SYMLINK_SUPPORT_DESCRIPTION": "Erlaubt WowUp Symlink-Ordner in deinem Addon-Ordner zu scannen. Warnung: Diese werden beim Aktualisieren/Installieren ersetzt."
+        "USE_SYMLINK_SUPPORT_DESCRIPTION": "Erlaubt WowUp Symlink-Ordner in deinem Addon-Ordner zu scannen. Warnung: Diese werden beim Aktualisieren/Installieren ersetzt.",
+        "KEEP_LAST_OPENED_TAB_LABEL": "Keep last opened tab",
+        "KEEP_LAST_OPENED_TAB_DESCRIPTION": "When opening an addon detail page, automatically select the last opened tab"
       },
       "DEBUG": {
         "CONFIG_FILES_BUTTON": "Konfigurationsdateien anzeigen",

--- a/wowup-electron/src/assets/i18n/en.json
+++ b/wowup-electron/src/assets/i18n/en.json
@@ -532,7 +532,9 @@
         "USE_SYMLINK_SUPPORT": "Enable Symlink Support",
         "USE_SYMLINK_SUPPORT_CONFIRMATION_DESCRIPTION": "Enabling symlink support will allow WowUp to recognize symlinks when performing a re-scan. Warning: If you do not know what a symlink is, you do not need this. When updating symlinks will currently be replaced with an actual folder and the link lost.",
         "USE_SYMLINK_SUPPORT_CONFIRMATION_LABEL": "Enable symlink support?",
-        "USE_SYMLINK_SUPPORT_DESCRIPTION": "Allow WowUp to scan symlink folders in your addon folder. Warning: they will be replaced when updating/installing."
+        "USE_SYMLINK_SUPPORT_DESCRIPTION": "Allow WowUp to scan symlink folders in your addon folder. Warning: they will be replaced when updating/installing.",
+        "KEEP_LAST_OPENED_TAB_LABEL": "Keep last opened tab",
+        "KEEP_LAST_OPENED_TAB_DESCRIPTION": "When opening an addon detail page, automatically select the last opened tab"
       },
       "DEBUG": {
         "CONFIG_FILES_BUTTON": "Show Config Files",

--- a/wowup-electron/src/assets/i18n/es.json
+++ b/wowup-electron/src/assets/i18n/es.json
@@ -532,7 +532,9 @@
         "USE_SYMLINK_SUPPORT": "Activar soporte de enlaces simbólicos (symlink)",
         "USE_SYMLINK_SUPPORT_CONFIRMATION_DESCRIPTION": "Activar el soporte de enlaces simbólicos permite a WowUp reconocerlos durante el reescaneo.\n\nAdvertencia: Si no sabe lo que es un enlace simbólico, no necesita activar esto. Al actualizar addons, los enlaces simbólicos serán reemplazados por copias de las carpetas y el enlace se perderá.",
         "USE_SYMLINK_SUPPORT_CONFIRMATION_LABEL": "¿Activar soporte de enlaces simbólicos?",
-        "USE_SYMLINK_SUPPORT_DESCRIPTION": "Permite a WowUp escanear enlaces simbólicos en la carpeta de addons.\nAdvertecia: Los enlaces serán reemplazados al actualizar/instalar los addons."
+        "USE_SYMLINK_SUPPORT_DESCRIPTION": "Permite a WowUp escanear enlaces simbólicos en la carpeta de addons.\nAdvertecia: Los enlaces serán reemplazados al actualizar/instalar los addons.",
+        "KEEP_LAST_OPENED_TAB_LABEL": "Keep last opened tab",
+        "KEEP_LAST_OPENED_TAB_DESCRIPTION": "When opening an addon detail page, automatically select the last opened tab"
       },
       "DEBUG": {
         "CONFIG_FILES_BUTTON": "Mostrar archivos de configuración",

--- a/wowup-electron/src/assets/i18n/fr.json
+++ b/wowup-electron/src/assets/i18n/fr.json
@@ -532,7 +532,9 @@
         "USE_SYMLINK_SUPPORT": "Enable Symlink Support",
         "USE_SYMLINK_SUPPORT_CONFIRMATION_DESCRIPTION": "Enabling symlink support will allow WowUp to recognize symlinks when performing a re-scan. Warning: If you do not know what a symlink is, you do not need this. When updating symlinks will currently be replaced with an actual folder and the link lost.",
         "USE_SYMLINK_SUPPORT_CONFIRMATION_LABEL": "Enable symlink support?",
-        "USE_SYMLINK_SUPPORT_DESCRIPTION": "Allow WowUp to scan symlink folders in your addon folder. Warning: they will be replaced when updating/installing."
+        "USE_SYMLINK_SUPPORT_DESCRIPTION": "Allow WowUp to scan symlink folders in your addon folder. Warning: they will be replaced when updating/installing.",
+        "KEEP_LAST_OPENED_TAB_LABEL": "Garder le dernier onglet de détail ouvert",
+        "KEEP_LAST_OPENED_TAB_DESCRIPTION": "A l'ouverture de la fenêtre de détails d'un addon, selectionne automatiquement le dernier onglet utilisé"
       },
       "DEBUG": {
         "CONFIG_FILES_BUTTON": "Show Config Files",

--- a/wowup-electron/src/assets/i18n/it.json
+++ b/wowup-electron/src/assets/i18n/it.json
@@ -532,7 +532,9 @@
         "USE_SYMLINK_SUPPORT": "Abilita il Supporto Symlink",
         "USE_SYMLINK_SUPPORT_CONFIRMATION_DESCRIPTION": "L'abilitazione del supporto symlink consentirà a WowUp di riconoscere i symlinks durante l'esecuzione di una nuova scansione. Attenzione: se non sai cos'è un symlink, puoi anche non procedere. Durante l'aggiornamento, i symlinks verranno sostituiti con una cartella reale e il collegamento viene perso.",
         "USE_SYMLINK_SUPPORT_CONFIRMATION_LABEL": "Abilitare il supporto symlink?",
-        "USE_SYMLINK_SUPPORT_DESCRIPTION": "Consenti a WowUp di scansionare le cartelle dei symlinks nella cartella dell'addon. Attenzione: verranno sostituiti durante l'aggiornamento/installazione."
+        "USE_SYMLINK_SUPPORT_DESCRIPTION": "Consenti a WowUp di scansionare le cartelle dei symlinks nella cartella dell'addon. Attenzione: verranno sostituiti durante l'aggiornamento/installazione.",
+        "KEEP_LAST_OPENED_TAB_LABEL": "Keep last opened tab",
+        "KEEP_LAST_OPENED_TAB_DESCRIPTION": "When opening an addon detail page, automatically select the last opened tab"
       },
       "DEBUG": {
         "CONFIG_FILES_BUTTON": "Show Config Files",

--- a/wowup-electron/src/assets/i18n/ko.json
+++ b/wowup-electron/src/assets/i18n/ko.json
@@ -532,7 +532,9 @@
         "USE_SYMLINK_SUPPORT": "Enable Symlink Support",
         "USE_SYMLINK_SUPPORT_CONFIRMATION_DESCRIPTION": "Enabling symlink support will allow WowUp to recognize symlinks when performing a re-scan. Warning: If you do not know what a symlink is, you do not need this. When updating symlinks will currently be replaced with an actual folder and the link lost.",
         "USE_SYMLINK_SUPPORT_CONFIRMATION_LABEL": "Enable symlink support?",
-        "USE_SYMLINK_SUPPORT_DESCRIPTION": "Allow WowUp to scan symlink folders in your addon folder. Warning: they will be replaced when updating/installing."
+        "USE_SYMLINK_SUPPORT_DESCRIPTION": "Allow WowUp to scan symlink folders in your addon folder. Warning: they will be replaced when updating/installing.",
+        "KEEP_LAST_OPENED_TAB_LABEL": "Keep last opened tab",
+        "KEEP_LAST_OPENED_TAB_DESCRIPTION": "When opening an addon detail page, automatically select the last opened tab"
       },
       "DEBUG": {
         "CONFIG_FILES_BUTTON": "Show Config Files",

--- a/wowup-electron/src/assets/i18n/nb.json
+++ b/wowup-electron/src/assets/i18n/nb.json
@@ -532,7 +532,9 @@
         "USE_SYMLINK_SUPPORT": "Enable Symlink Support",
         "USE_SYMLINK_SUPPORT_CONFIRMATION_DESCRIPTION": "Enabling symlink support will allow WowUp to recognize symlinks when performing a re-scan. Warning: If you do not know what a symlink is, you do not need this. When updating symlinks will currently be replaced with an actual folder and the link lost.",
         "USE_SYMLINK_SUPPORT_CONFIRMATION_LABEL": "Enable symlink support?",
-        "USE_SYMLINK_SUPPORT_DESCRIPTION": "Allow WowUp to scan symlink folders in your addon folder. Warning: they will be replaced when updating/installing."
+        "USE_SYMLINK_SUPPORT_DESCRIPTION": "Allow WowUp to scan symlink folders in your addon folder. Warning: they will be replaced when updating/installing.",
+        "KEEP_LAST_OPENED_TAB_LABEL": "Keep last opened tab",
+        "KEEP_LAST_OPENED_TAB_DESCRIPTION": "When opening an addon detail page, automatically select the last opened tab"
       },
       "DEBUG": {
         "CONFIG_FILES_BUTTON": "Show Config Files",

--- a/wowup-electron/src/assets/i18n/pl.json
+++ b/wowup-electron/src/assets/i18n/pl.json
@@ -532,7 +532,9 @@
         "USE_SYMLINK_SUPPORT": "Włącz obsługę Symlink",
         "USE_SYMLINK_SUPPORT_CONFIRMATION_DESCRIPTION": "Włączenie obsługi symlink pozwoli WowUp na rozpoznawanie symlinków podczas ponownego skanowania. Ostrzeżenie: Jeśli nie wiesz, co to jest symlink, nie potrzebujesz tego. Podczas aktualizacji symlink będzie obecnie zastępowany rzeczywistym folderem, a link zostanie utracony.",
         "USE_SYMLINK_SUPPORT_CONFIRMATION_LABEL": "Włączyć obsługę symlink?",
-        "USE_SYMLINK_SUPPORT_DESCRIPTION": "Pozwól WowUp na skanowanie folderów z symlinkami w folderze addonów. Ostrzeżenie: zostaną one zastąpione podczas aktualizacji/instalacji."
+        "USE_SYMLINK_SUPPORT_DESCRIPTION": "Pozwól WowUp na skanowanie folderów z symlinkami w folderze addonów. Ostrzeżenie: zostaną one zastąpione podczas aktualizacji/instalacji.",
+        "KEEP_LAST_OPENED_TAB_LABEL": "Keep last opened tab",
+        "KEEP_LAST_OPENED_TAB_DESCRIPTION": "When opening an addon detail page, automatically select the last opened tab"
       },
       "DEBUG": {
         "CONFIG_FILES_BUTTON": "Pokaż pliki konfiguracyjne",

--- a/wowup-electron/src/assets/i18n/pt.json
+++ b/wowup-electron/src/assets/i18n/pt.json
@@ -532,7 +532,9 @@
         "USE_SYMLINK_SUPPORT": "Habilitar suporte a Symlink",
         "USE_SYMLINK_SUPPORT_CONFIRMATION_DESCRIPTION": "Habilitando o suporte à symlink irá permitir ao WowUp reconhecer symlinks quando fazer um re-escaneamento. Aviso: Se você não sabe o que é um symlink, você não precisa disso. Quando atualizar os symlinks serão atualmente substituídos com uma pasta e o link será perdido.",
         "USE_SYMLINK_SUPPORT_CONFIRMATION_LABEL": "Habilitar suporte a symlink?",
-        "USE_SYMLINK_SUPPORT_DESCRIPTION": "Permitir ao WowUp escanear pastas symlink na sua pasta de Addons. Aviso: elas serão substituidas quando atualizar/instalar."
+        "USE_SYMLINK_SUPPORT_DESCRIPTION": "Permitir ao WowUp escanear pastas symlink na sua pasta de Addons. Aviso: elas serão substituidas quando atualizar/instalar.",
+        "KEEP_LAST_OPENED_TAB_LABEL": "Keep last opened tab",
+        "KEEP_LAST_OPENED_TAB_DESCRIPTION": "When opening an addon detail page, automatically select the last opened tab"
       },
       "DEBUG": {
         "CONFIG_FILES_BUTTON": "Show Config Files",

--- a/wowup-electron/src/assets/i18n/ru.json
+++ b/wowup-electron/src/assets/i18n/ru.json
@@ -532,7 +532,9 @@
         "USE_SYMLINK_SUPPORT": "Включить поддержку символических ссылок",
         "USE_SYMLINK_SUPPORT_CONFIRMATION_DESCRIPTION": "Включение поддержки символических ссылок позволит WowUp распознавать их при повторном сканировании. Предупреждение: Если Вы не знаете, что такое символическая ссылка, то, скорее всего, Вам это не нужно. При обновлении символические ссылки в настоящее время будут заменены фактической папкой, и ссылка будет потеряна.",
         "USE_SYMLINK_SUPPORT_CONFIRMATION_LABEL": "Включить поддержку символических ссылок?",
-        "USE_SYMLINK_SUPPORT_DESCRIPTION": "Разрешает WowUp сканировать папки символических ссылок в папке Вашей модификации. Предупреждение: они будут заменены при обновлении/установке."
+        "USE_SYMLINK_SUPPORT_DESCRIPTION": "Разрешает WowUp сканировать папки символических ссылок в папке Вашей модификации. Предупреждение: они будут заменены при обновлении/установке.",
+        "KEEP_LAST_OPENED_TAB_LABEL": "Keep last opened tab",
+        "KEEP_LAST_OPENED_TAB_DESCRIPTION": "When opening an addon detail page, automatically select the last opened tab"
       },
       "DEBUG": {
         "CONFIG_FILES_BUTTON": "Показать файлы настроек",

--- a/wowup-electron/src/assets/i18n/zh-TW.json
+++ b/wowup-electron/src/assets/i18n/zh-TW.json
@@ -532,7 +532,9 @@
         "USE_SYMLINK_SUPPORT": "啟用符號連結",
         "USE_SYMLINK_SUPPORT_CONFIRMATION_DESCRIPTION": "啟用符號連結使得 WowUp 在重新掃描時識別符號連結。警告：如果您不知道什麼是符號連結，請禁用此項。在當前版本中，符號連結將會在更新插件時被刪除，並被替換為真正的資料夾。",
         "USE_SYMLINK_SUPPORT_CONFIRMATION_LABEL": "啟用符號連結？",
-        "USE_SYMLINK_SUPPORT_DESCRIPTION": "允許 WowUp 掃描插件所在路徑下的符號連結。警告：符號連結在安裝或更新插件時會被替換。"
+        "USE_SYMLINK_SUPPORT_DESCRIPTION": "允許 WowUp 掃描插件所在路徑下的符號連結。警告：符號連結在安裝或更新插件時會被替換。",
+        "KEEP_LAST_OPENED_TAB_LABEL": "Keep last opened tab",
+        "KEEP_LAST_OPENED_TAB_DESCRIPTION": "When opening an addon detail page, automatically select the last opened tab"
       },
       "DEBUG": {
         "CONFIG_FILES_BUTTON": "Show Config Files",

--- a/wowup-electron/src/assets/i18n/zh.json
+++ b/wowup-electron/src/assets/i18n/zh.json
@@ -532,7 +532,9 @@
         "USE_SYMLINK_SUPPORT": "启用符号链接",
         "USE_SYMLINK_SUPPORT_CONFIRMATION_DESCRIPTION": "启用符号链接使得 WowUp 在重新扫描时识别符号链接。警告：如果您不知道什么是符号链接，请禁用此项。在当前版本中，符号链接将会在更新插件时被删除，并被替换为真正的文件夹。",
         "USE_SYMLINK_SUPPORT_CONFIRMATION_LABEL": "启用符号链接？",
-        "USE_SYMLINK_SUPPORT_DESCRIPTION": "允许 WowUp 扫描插件所在路径下的符号链接。警告：符号链接在安装或更新插件时会被替换。"
+        "USE_SYMLINK_SUPPORT_DESCRIPTION": "允许 WowUp 扫描插件所在路径下的符号链接。警告：符号链接在安装或更新插件时会被替换。",
+        "KEEP_LAST_OPENED_TAB_LABEL": "Keep last opened tab",
+        "KEEP_LAST_OPENED_TAB_DESCRIPTION": "When opening an addon detail page, automatically select the last opened tab"
       },
       "DEBUG": {
         "CONFIG_FILES_BUTTON": "Show Config Files",

--- a/wowup-electron/src/common/constants.ts
+++ b/wowup-electron/src/common/constants.ts
@@ -124,6 +124,7 @@ export const USE_SYMLINK_MODE_PREFERENCE_KEY = "use_symlink_mode";
 export const START_WITH_SYSTEM_PREFERENCE_KEY = "start_with_system";
 export const START_MINIMIZED_PREFERENCE_KEY = "start_minimized";
 export const SELECTED_LANGUAGE_PREFERENCE_KEY = "selected_language";
+export const KEEP_ADDON_DETAIL_TAB_PREFERENCE_KEY = "keep_addon_detail_tab";
 export const MY_ADDONS_HIDDEN_COLUMNS_KEY = "my_addons_hidden_columns";
 export const MY_ADDONS_SORT_ORDER = "my_addons_sort_order";
 export const GET_ADDONS_HIDDEN_COLUMNS_KEY = "get_addons_hidden_columns";
@@ -175,7 +176,15 @@ export const MIN_VISIBLE_ON_SCREEN = 32;
 export const WOWUP_LOGO_FILENAME = "wowup_logo_purple.png";
 export const WOWUP_LOGO_MAC_SYSTEM_TRAY = "wowupBlackLgNopadTemplate.png";
 export const DEFAULT_FILE_MODE = 0o655;
-export const DEFAULT_TRUSTED_DOMAINS = ["wowup.io", "dev.wowup.io", "discord.gg", "www.patreon.com", "github.com", "wago.io", "addons.wago.io"];
+export const DEFAULT_TRUSTED_DOMAINS = [
+  "wowup.io",
+  "dev.wowup.io",
+  "discord.gg",
+  "www.patreon.com",
+  "github.com",
+  "wago.io",
+  "addons.wago.io",
+];
 export const WOW_CLASSIC_FOLDER = "_classic_";
 export const WOW_CLASSIC_ERA_FOLDER = "_classic_era_";
 export const WOW_RETAIL_FOLDER = "_retail_";

--- a/wowup-electron/src/typings.d.ts
+++ b/wowup-electron/src/typings.d.ts
@@ -8,5 +8,5 @@ interface Window {
   require: any;
 }
 
-declare type DetailsTabType = "description" | "changelog";
+declare type DetailsTabType = "description" | "changelog" | "previews";
 declare type AddonIgnoreReason = "git_repo" | "missing_dependency" | "unknown";


### PR DESCRIPTION
Fix issue #789
Add an option in the application's options to preserve the last opened tab in the addon details, for all tabs including previews.
By default, open the detail modal on the description tab.