### PR TITLE
Added option to bypass allowModDistribution flag

### DIFF
--- a/wowup-electron/src/app/addon-providers/curse-addon-v2-provider.ts
+++ b/wowup-electron/src/app/addon-providers/curse-addon-v2-provider.ts
@@ -24,6 +24,7 @@ import {
   NO_LATEST_SEARCH_RESULT_FILES_ERROR,
   NO_SEARCH_RESULTS_ERROR,
   PREF_CF2_API_KEY,
+  PREF_CF2_BYPASS_UNAVAILABLE,
 } from "../../common/constants";
 import { CurseAddonCategory, CurseGameVersionFlavor } from "../../common/curse/curse-models";
 import { Addon } from "../../common/entities/addon";
@@ -49,6 +50,7 @@ import { strictFilter } from "../utils/array.utils";
 import { TocService } from "../services/toc/toc.service";
 import { WarcraftService } from "../services/warcraft/warcraft.service";
 import { SensitiveStorageService } from "../services/storage/sensitive-storage.service";
+import { PreferenceStorageService } from "../services/storage/preference-storage.service";
 import { getWowClientGroup } from "../../common/warcraft";
 
 interface ProtocolData {
@@ -100,6 +102,7 @@ export class CurseAddonV2Provider extends AddonProvider {
     private _warcraftService: WarcraftService,
     private _tocService: TocService,
     private _sensitiveStorageService: SensitiveStorageService,
+    private _preferenceStorageService: PreferenceStorageService,
     _networkService: NetworkService
   ) {
     super();
@@ -660,7 +663,10 @@ export class CurseAddonV2Provider extends AddonProvider {
         downloadCount: result.downloadCount,
         summary: result.summary,
         screenshotUrls: this.getScreenshotUrls(result),
-        externallyBlocked: result.allowModDistribution === false,
+        externallyBlocked: (
+          this._preferenceStorageService.getSync(PREF_CF2_BYPASS_UNAVAILABLE) !== "true"
+          && result.allowModDistribution === false
+        ),
       };
 
       return searchResult;

--- a/wowup-electron/src/app/components/options/options-addon-section/options-addon-section.component.html
+++ b/wowup-electron/src/app/components/options/options-addon-section/options-addon-section.component.html
@@ -41,6 +41,22 @@
         <input matInput formControlName="cfV2ApiKey" type="password" />
       </mat-form-field>
     </div>
+
+    <div class="divider"></div>
+    <div class="setting row align-items-center">
+      <div class="flex-grow-1">
+        <div>
+          {{ "PAGES.OPTIONS.ADDON.CURSE_FORGE_V2.BYPASS_UNAVAILABLE_TITLE" | translate }}
+        </div>
+        <small class="text-2">
+          {{ "PAGES.OPTIONS.ADDON.CURSE_FORGE_V2.BYPASS_UNAVAILABLE_DESCRIPTION" | translate }}
+        </small>
+      </div>
+      <mat-slide-toggle
+        [checked]="cfV2BypassUnavailable$ | async" (change)="onBypassUnavailableChange($event)"
+      ></mat-slide-toggle>
+    </div>
+
     <div class="divider"></div>
     <div class="setting row align-items-center">
       <div class="flex-grow-1">

--- a/wowup-electron/src/app/services/addons/addon.provider.factory.ts
+++ b/wowup-electron/src/app/services/addons/addon.provider.factory.ts
@@ -137,6 +137,7 @@ export class AddonProviderFactory {
       this._warcraftService,
       this._tocService,
       this._sensitiveStorageService,
+      this._preferenceStorageService,
       this._networkService
     );
   }

--- a/wowup-electron/src/assets/i18n/en.json
+++ b/wowup-electron/src/assets/i18n/en.json
@@ -486,6 +486,8 @@
         "CURSE_FORGE_V2": {
           "API_KEY_DESCRIPTION": "If you have requested a CurseForge API key you can input it here to connect to their API.",
           "API_KEY_TITLE": "CurseForge API Key",
+          "BYPASS_UNAVAILABLE_DESCRIPTION": "Ignore restrictions to distribute some addons from CurseForge.",
+          "BYPASS_UNAVAILABLE_TITLE": "Bypass 3rd party restriction for CurseForge",
           "PROVIDER_NOTE": "API Key Required"
         },
         "ENABLED_PROVIDERS": {

--- a/wowup-electron/src/common/constants.ts
+++ b/wowup-electron/src/common/constants.ts
@@ -149,8 +149,8 @@ export const ACCT_PUSH_ENABLED_KEY = "acct_push_enabled";
 export const WAGO_PROMPT_KEY = "wago_prompt";
 export const PREF_TABS_COLLAPSED = "tabs_collapsed";
 export const PREF_CF2_API_KEY = "cf2_api_key";
+export const PREF_CF2_BYPASS_UNAVAILABLE = "cf2_bypass_unavailable";
 export const PREF_GITHUB_PERSONAL_ACCESS_TOKEN = "github_personal_access_token";
-
 export const ACCT_FEATURE_KEYS = [ACCT_PUSH_ENABLED_KEY];
 
 // THEMES


### PR DESCRIPTION
## Summary

Added single toggle to options (disabled by default).

With enabled toggle CurseV2 provider ignores `allowModDistribution` flag and allow install any addon.

## Reasons

1. Some addons still provided only by CF, this toggle let users retain access to them.
2. Users provides their own keys, so they should have options to the way it uses.
Its ToS between user and CF, not between CF and WowUp.
3. CF app ignores that flag in the same way.

## Screenshots

#### New toggle in options
![image](https://user-images.githubusercontent.com/2664578/168491461-be8dcbee-a6e2-42b4-ab4e-38916d74c40e.png)

#### Enabled toggle
![image](https://user-images.githubusercontent.com/2664578/168491496-2d66ce2d-386d-46df-a654-f9e50f222dd2.png)

#### Disabled toggle (by default)
![image](https://user-images.githubusercontent.com/2664578/168491503-3ef80064-23c2-468e-8c45-673038b82f3e.png)
