### PR TITLE
Show details on warning

### DIFF
--- a/wowup-electron/src/app/components/addons/my-addons-addon-cell/my-addons-addon-cell.component.scss
+++ b/wowup-electron/src/app/components/addons/my-addons-addon-cell/my-addons-addon-cell.component.scss
@@ -78,11 +78,6 @@
       text-decoration: underline;
       color: var(--text-2);
     }
-
-    &.text-warning:hover {
-      cursor: inherit;
-      text-decoration: none;
-    }
   }
 
   .addon-version {

--- a/wowup-electron/src/app/services/dialog/dialog.factory.ts
+++ b/wowup-electron/src/app/services/dialog/dialog.factory.ts
@@ -53,11 +53,6 @@ export class DialogFactory {
   }
 
   public getAddonDetailsDialog(listItem: AddonViewModel): MatDialogRef<AddonDetailComponent, any> | undefined {
-    // If this addon is in warning state, we wont be able to get details
-    if (listItem.addon?.warningType !== undefined) {
-      return;
-    }
-
     const data: AddonDetailModel = {
       listItem: listItem.clone(),
     };


### PR DESCRIPTION
This effectively lets users open the addon details when there is a warning. Most of the information comes from the local system anyway, so imo we should just try to show whatever we got. This does expose the "up-to-date" or "update" button inside, and I'm not sure what the behavior should be here. I suppose we can just leave it like this?

![](https://media.giphy.com/media/tFd8IqytjBirSP5uJd/giphy.gif)