### PR TITLE
Allow removing addons that have no directories

### DIFF
--- a/wowup-electron/src/app/services/addons/addon.service.ts
+++ b/wowup-electron/src/app/services/addons/addon.service.ts
@@ -980,8 +980,8 @@ export class AddonService {
 
     console.log(`[RemoveAddon] ${addon.providerName ?? ""} ${addon.externalId ?? "NO_EXT_ID"} ${addon.name}`);
 
-    if (removeDirectories) {
-      const installedDirectories = addon.installedFolderList ?? [];
+    const installedDirectories = addon.installedFolderList ?? [];
+    if (removeDirectories && installedDirectories.length > 0) {
       const installation = this._warcraftInstallationService.getWowInstallation(addon.installationId);
       if (!installation) {
         console.warn("No installation found for remove", addon.installationId);


### PR DESCRIPTION
In odd scenarios users can install addons with 0 directories,through install from URL. In the addon delete check it sees that the amount of failures and directories are equal and then errors, but there's nothing to delete with 0 directories.