### PR TITLE
Allow removal of addons that had their dirs removed prior to delete

### DIFF
--- a/wowup-electron/src/app/services/addons/addon.service.ts
+++ b/wowup-electron/src/app/services/addons/addon.service.ts
@@ -997,7 +997,7 @@ export class AddonService {
           `[RemoveAddonDirectory] ${addon.providerName ?? ""} ${addon.externalId ?? "NO_EXT_ID"} ${addonDirectory}`
         );
         try {
-          await this._fileService.remove(addonDirectory);
+          await this._fileService.deleteIfExists(addonDirectory);
         } catch (e) {
           console.error(e);
           failureCt += 1;


### PR DESCRIPTION
Fixes #1270 

The goal of this part is to remove addons. If the addon is already removed, it should just continue