### PR TITLE
Fix API_URL for github

### DIFF
--- a/wowup-electron/src/app/addon-providers/github-addon-provider.ts
+++ b/wowup-electron/src/app/addon-providers/github-addon-provider.ts
@@ -56,7 +56,7 @@ interface ReleaseMetaItemMetadata {
   interface: number;
 }
 
-const API_URL = "https://api.com/repos";
+const API_URL = "https://api.github.com/repos";
 const RELEASE_CONTENT_TYPES = {
   XZIP: "application/x-zip-compressed",
   ZIP: "application/zip",


### PR DESCRIPTION
I actually didn't check the develop branch (I'll blame it on me just waking up so was kind of groggy and wasn't fully aware of things at the time) but this fixes it on WAGO version of WOWUP as well now.