### PR TITLE
Fix duplicated addons in my addons page

### DIFF
--- a/wowup-electron/app/ipc-events.ts
+++ b/wowup-electron/app/ipc-events.ts
@@ -253,6 +253,8 @@ export function initializeIpcHandlers(window: BrowserWindow): void {
       return;
     }
 
+    addonStore.clear();
+
     for (const addon of addons) {
       if (typeof addon.id !== "string") {
         log.warn("malformed addon not saved", addon);


### PR DESCRIPTION
I'm not sure if there is an issue for this on this repository, but I have previously opened one on WowUp.CF repository.
Closing https://github.com/WowUp/WowUp.CF/issues/60

### Explanation of the bug

The bug appears on first loading of the app when there is no electron-store saved in user app data.
The app is calling 3 times `AddonStorageService.saveAll()` from `AddonService.rescanInstallation()` from `AddonService.getAddons()` from `MyAddonsComponent.loadAddons()`.

2 times by this `switchMap` : 
```typescript
 this._sessionService.autoUpdateComplete$
      .pipe(
        tap(() => console.log("Checking for addon updates...")),
        switchMap(() => from(this.loadAddons()))
      )
      .subscribe(() => {
        this._cdRef.markForCheck();
      });
```
Because `autoUpdateComplete` is a `BehaviorSubject` so it emits it's firstValue `0` then when `SessionService.autoUpdateComplete()` is called.

1 time inside `MyAddonsComponent.lazyLoad()`.

`AddonService.rescanInstallation()` is called 3 times rapidly and because it's a Promise, it's beginning each call without waiting for the other one to finish.

From a UI perspective, we are updating only with one result from `MyAddonsComponent.loadAddons()` so we are not seeing any problem.

But the `handle` of `IPC_ADDONS_SAVE_ALL` in `ipc-events.ts` is not clearing the store, it can have 3 times the same addon in the store.

So when the user relaunch the application or clicking on `PAGES.MY_ADDONS.CHECK_UPDATES_BUTTON_TOOLTIP` button and getting the addons from the store, it shows the addons duplicated.

### Explanation of my fix

It's working because `IPC_ADDONS_SAVE_ALL` is only called from `AddonStorage.saveAll()` which is only called from `AddonService.rescanInstallation()` so it has all the addons from the disk and it's not losing any data.

But a better fix would be to either : 
- only call 1 time `MyAddonsComponent.loadAddons()`
- implement a way to not do `AddonService.rescanInstallation()` if one is already in progress

