### PR TITLE
Add install instructions using WinGet

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,21 @@ If you feel like helping us test the latest and greatest changes beta builds are
 
 ### Community Support Alternatives
 
-[Chocolatey](https://chocolatey.org)
+#### [WinGet](https://learn.microsoft.com/en-us/windows/package-manager/winget/)
+
+Ships with Windows 10 and 11.  You can install WowUp With Wago using:
+
+```cmd
+winget install wowup.wowup
+```
+
+Or Wowup with CurseForge with:
+
+```cmd
+winget install wowup.cf
+```
+
+#### [Chocolatey](https://chocolatey.org)
 
 You can also install the latest version via Chocolatey package manager:
 


### PR DESCRIPTION
[WinGet](https://learn.microsoft.com/en-us/windows/package-manager/winget/) has shipped with Win10 since 2017 and all Win11 installs.  It's source of truth is here: https://github.com/microsoft/winget-pkgs.  You can see the [CF version](https://github.com/microsoft/winget-pkgs/tree/master/manifests/w/WowUp/CF).  It pulls directly from the WowUp releases, as can be seen in the configs ([example](https://github.com/microsoft/winget-pkgs/blob/master/manifests/w/WowUp/Wowup/2.20.0/WowUp.Wowup.installer.yaml)).

Updates to the configs are done via issues submitted to the project: https://github.com/microsoft/winget-pkgs/issues/new/choose