### PR TITLE
sync github download url handling for the update flow to match the inital install flow

### DIFF
--- a/wowup-electron/src/app/addon-providers/github-addon-provider.ts
+++ b/wowup-electron/src/app/addon-providers/github-addon-provider.ts
@@ -249,7 +249,7 @@ export class GitHubAddonProvider extends AddonProvider {
 
     const searchResultFile: AddonSearchResultFile = {
       channelType: AddonChannelType.Stable,
-      downloadUrl: asset?.url ?? "",
+      downloadUrl: asset?.browser_download_url || asset?.url || "",
       folders: [addonName],
       gameVersion: "",
       version: asset?.name ?? "",


### PR DESCRIPTION
this should fix the issue that addons installed via url from a public github repo cannot be updated