### PR TITLE
Update LSApplicationCategoryType from Games to Utilities

### DIFF
--- a/wowup-electron/electron-build/electron-builder-local-ow.json
+++ b/wowup-electron/electron-build/electron-builder-local-ow.json
@@ -21,7 +21,7 @@
   },
   "mac": {
     "icon": "electron-build/icon.icns",
-    "category": "public.app-category.games",
+    "category": "public.app-category.utilities",
     "target": [
       {
         "target": "default",

--- a/wowup-electron/electron-build/electron-builder-local.json
+++ b/wowup-electron/electron-build/electron-builder-local.json
@@ -21,7 +21,7 @@
   },
   "mac": {
     "icon": "electron-build/icon.icns",
-    "category": "public.app-category.games",
+    "category": "public.app-category.utilities",
     "target": [
       {
         "target": "default",

--- a/wowup-electron/electron-build/electron-builder-ow.json
+++ b/wowup-electron/electron-build/electron-builder-ow.json
@@ -20,7 +20,7 @@
   },
   "mac": {
     "icon": "electron-build/icon.icns",
-    "category": "public.app-category.games",
+    "category": "public.app-category.utilities",
     "target": [
       {
         "target": "default",

--- a/wowup-electron/electron-build/electron-builder.json
+++ b/wowup-electron/electron-build/electron-builder.json
@@ -20,7 +20,7 @@
   },
   "mac": {
     "icon": "electron-build/icon.icns",
-    "category": "public.app-category.games",
+    "category": "public.app-category.utilities",
     "target": [
       {
         "target": "default",


### PR DESCRIPTION
The WowUp Mac app is configured with an [LSApplicationCategoryType](https://developer.apple.com/documentation/bundleresources/information-property-list/lsapplicationcategorytype) of Games, as seen in `WowUp.app/Contents/Info.plist`. This erroneously causes [Game Mode](https://support.apple.com/en-us/105118) to start when WowUp is running on macOS.

This PR changes the LSApplicationCategoryType from Games to Utilities, better reflecting the purpose of the app and preventing Game Mode from starting unexpectedly.