### PR TITLE
Linux Flatpak builds

### DIFF
--- a/wowup-electron/electron-build/electron-builder-local-ow.json
+++ b/wowup-electron/electron-build/electron-builder-local-ow.json
@@ -33,17 +33,24 @@
   },
   "linux": {
     "icon": "electron-build/flatpak/",
-    "target": ["AppImage"]
+    "target": [
+      "AppImage",
+      {
+        "target": "flatpak",
+        "arch": ["x64"]  
+      }
+    ],
+    "asarUnpack": "**/*.node"
   },
   "flatpak": {
     "base": "org.electronjs.Electron2.BaseApp",
+    "baseVersion": "25.08",
     "runtime": "org.freedesktop.Platform",
-    "runtimeVersion": "21.08",
+    "runtimeVersion": "25.08",
     "sdk": "org.freedesktop.Sdk",
-    "baseVersion": "21.08",
     "finishArgs": [
       "--socket=wayland",
-      "--socket=x11",
+      "--socket=fallback-x11",
       "--socket=pulseaudio",
       "--socket=system-bus",
       "--socket=session-bus",
@@ -52,12 +59,15 @@
       "--device=dri",
       "--filesystem=xdg-config/WoWUp",
       "--filesystem=~/Games",
-      "--filesystem=~/.wine/drive_c",
+      "--filesystem=~/Bottles",
+      "--filesystem=~/Faugus",
+      "--filesystem=~/.wine",
+      "--filesystem=/mnt",
       "--talk-name=org.freedesktop.Notifications",
       "--talk-name=org.gtk.Notifications",
       "--talk-name=org.kde.StatusNotifierWatcher",
       "--env=APPIMAGE=true"
     ],
-    "useWaylandFlags": false
+    "useWaylandFlags": true
   }
 }

--- a/wowup-electron/electron-build/electron-builder-local.json
+++ b/wowup-electron/electron-build/electron-builder-local.json
@@ -33,17 +33,24 @@
   },
   "linux": {
     "icon": "electron-build/flatpak/",
-    "target": ["AppImage"]
+    "target": [
+      "AppImage",
+      {
+        "target": "flatpak",
+        "arch": ["x64"]  
+      }
+    ],
+    "asarUnpack": "**/*.node"
   },
   "flatpak": {
     "base": "org.electronjs.Electron2.BaseApp",
+    "baseVersion": "25.08",
     "runtime": "org.freedesktop.Platform",
-    "runtimeVersion": "21.08",
+    "runtimeVersion": "25.08",
     "sdk": "org.freedesktop.Sdk",
-    "baseVersion": "21.08",
     "finishArgs": [
       "--socket=wayland",
-      "--socket=x11",
+      "--socket=fallback-x11",
       "--socket=pulseaudio",
       "--socket=system-bus",
       "--socket=session-bus",
@@ -52,12 +59,15 @@
       "--device=dri",
       "--filesystem=xdg-config/WoWUp",
       "--filesystem=~/Games",
-      "--filesystem=~/.wine/drive_c",
+      "--filesystem=~/Bottles",
+      "--filesystem=~/Faugus",
+      "--filesystem=~/.wine",
+      "--filesystem=/mnt",
       "--talk-name=org.freedesktop.Notifications",
       "--talk-name=org.gtk.Notifications",
       "--talk-name=org.kde.StatusNotifierWatcher",
       "--env=APPIMAGE=true"
     ],
-    "useWaylandFlags": false
+    "useWaylandFlags": true
   }
 }

--- a/wowup-electron/electron-build/electron-builder-ow.json
+++ b/wowup-electron/electron-build/electron-builder-ow.json
@@ -51,18 +51,24 @@
   },
   "linux": {
     "icon": "electron-build/flatpak/",
-    "target": ["AppImage"],
+    "target": [
+      "AppImage",
+      {
+        "target": "flatpak",
+        "arch": ["x64"]  
+      }
+    ],
     "asarUnpack": "**/*.node"
   },
   "flatpak": {
     "base": "org.electronjs.Electron2.BaseApp",
+    "baseVersion": "25.08",
     "runtime": "org.freedesktop.Platform",
-    "runtimeVersion": "21.08",
+    "runtimeVersion": "25.08",
     "sdk": "org.freedesktop.Sdk",
-    "baseVersion": "21.08",
     "finishArgs": [
       "--socket=wayland",
-      "--socket=x11",
+      "--socket=fallback-x11",
       "--socket=pulseaudio",
       "--socket=system-bus",
       "--socket=session-bus",
@@ -71,12 +77,15 @@
       "--device=dri",
       "--filesystem=xdg-config/WoWUp",
       "--filesystem=~/Games",
-      "--filesystem=~/.wine/drive_c",
+      "--filesystem=~/Bottles",
+      "--filesystem=~/Faugus",
+      "--filesystem=~/.wine",
+      "--filesystem=/mnt",
       "--talk-name=org.freedesktop.Notifications",
       "--talk-name=org.gtk.Notifications",
       "--talk-name=org.kde.StatusNotifierWatcher",
       "--env=APPIMAGE=true"
     ],
-    "useWaylandFlags": false
+    "useWaylandFlags": true
   }
 }

--- a/wowup-electron/electron-build/electron-builder.json
+++ b/wowup-electron/electron-build/electron-builder.json
@@ -45,18 +45,24 @@
   },
   "linux": {
     "icon": "electron-build/flatpak/",
-    "target": ["AppImage"],
+    "target": [
+      "AppImage",
+      {
+        "target": "flatpak",
+        "arch": ["x64"]  
+      }
+    ],
     "asarUnpack": "**/*.node"
   },
   "flatpak": {
     "base": "org.electronjs.Electron2.BaseApp",
+    "baseVersion": "25.08",
     "runtime": "org.freedesktop.Platform",
-    "runtimeVersion": "21.08",
+    "runtimeVersion": "25.08",
     "sdk": "org.freedesktop.Sdk",
-    "baseVersion": "21.08",
     "finishArgs": [
       "--socket=wayland",
-      "--socket=x11",
+      "--socket=fallback-x11",
       "--socket=pulseaudio",
       "--socket=system-bus",
       "--socket=session-bus",
@@ -65,12 +71,15 @@
       "--device=dri",
       "--filesystem=xdg-config/WoWUp",
       "--filesystem=~/Games",
-      "--filesystem=~/.wine/drive_c",
+      "--filesystem=~/Bottles",
+      "--filesystem=~/Faugus",
+      "--filesystem=~/.wine",
+      "--filesystem=/mnt",
       "--talk-name=org.freedesktop.Notifications",
       "--talk-name=org.gtk.Notifications",
       "--talk-name=org.kde.StatusNotifierWatcher",
       "--env=APPIMAGE=true"
     ],
-    "useWaylandFlags": false
+    "useWaylandFlags": true
   }
 }


### PR DESCRIPTION
Hello, I am not sure if you would want to break this up to add a script or instructions. 
You could have a linux or flatpak specific .json maybe.
Only tested with default "wago" build. 
 
This will build with
`npm run electron:publish`
but it will error out on the flatpak step if the pre-reqs are not installed. If it errors, the Appimage build appears to still work ok and appear in the normal location. 

I will add more notes in comment. 

You should be able to publish as a verified app to https://www.flathub.org with a flatpak build & a valid repo license. 
If you have a flatpak build, it can also be submitted as a unofficial app by someone if you do not want to. 