### PR TITLE
Fix cross-platform build, locale tests, and import error UX

### DIFF
--- a/wowup-electron/src/app/addon-providers/github-addon-provider.ts
+++ b/wowup-electron/src/app/addon-providers/github-addon-provider.ts
@@ -249,7 +249,7 @@ export class GitHubAddonProvider extends AddonProvider {
 
     const searchResultFile: AddonSearchResultFile = {
       channelType: AddonChannelType.Stable,
-      downloadUrl: asset?.url ?? "",
+      downloadUrl: asset?.browser_download_url || asset?.url || "",
       folders: [addonName],
       gameVersion: "",
       version: asset?.name ?? "",

--- a/wowup-electron/src/app/services/addons/addon-broker.service.ts
+++ b/wowup-electron/src/app/services/addons/addon-broker.service.ts
@@ -191,6 +191,10 @@ export class AddonBrokerService {
 
     if (!this.isSameClient(installation.clientType, exportPayload.client_type)) {
       summary.errorCode = "INVALID_CLIENT_TYPE";
+      summary.errorParams = {
+        importedClient: exportPayload.client_type || "unknown",
+        targetClient: this.getClientType(installation.clientType),
+      };
       return summary;
     }
 

--- a/wowup-electron/src/assets/i18n/en.json
+++ b/wowup-electron/src/assets/i18n/en.json
@@ -24,7 +24,7 @@
     "IMPORT_TEXT_LABEL": "Import data",
     "IMPORT_TOTAL_COUNT": "Importing {count} {count, plural, =1{addon} other{addons}}",
     "INSTALL_BUTTON": "Install",
-    "INVALID_CLIENT_TYPE": "Import string did not match your selected client type",
+    "INVALID_CLIENT_TYPE": "Import is for client \"{importedClient}\", but the selected installation is \"{targetClient}\". Re-export from a current install if the export was made on an older version.",
     "MISSING_ADDON_PROVIDERS": "One or more addon providers were not available/enabled ({missingProviders})",
     "MISSING_CURSEFORGE_PROVIDER": "Addon list contains a CurseForge addon, you will need to install<br>\"WowUp with CurseForge\" from wowup.io",
     "MISSING_PROVIDER_MODAL_DOWNLOAD_BTN": "Download",

--- a/wowup-electron/src/locales.spec.ts
+++ b/wowup-electron/src/locales.spec.ts
@@ -8,7 +8,7 @@ import { catchError, firstValueFrom, Observable, of } from "rxjs";
 import MessageFormat, { MessageFormatOptions } from "@messageformat/core";
 
 const LOCALES = ["cs", "de", "en", "es", "fr", "it", "ko", "nb", "pt", "ru", "zh-TW", "zh"];
-const LOCALE_DIR = path.join(__dirname, "..", "..", "..", "..", "..", "..", "src", "assets", "i18n");
+const LOCALE_DIR = path.resolve(process.cwd(), "src", "assets", "i18n");
 
 const LOCALE_SET = {};
 

--- a/wowup-lib/package.json
+++ b/wowup-lib/package.json
@@ -6,7 +6,7 @@
   "types": "lib/index.d.ts",
   "source": "src/index.ts",
   "scripts": {
-    "build": "cross-env TEMP=D:\\Temp parcel build",
+    "build": "parcel build",
     "format": "prettier --write \"src/**/*.ts\" \"src/**/*.js\"",
     "lint": "eslint .",
     "postversion": "git push && git push --tags",

--- a/wowup-lib/src/index.ts
+++ b/wowup-lib/src/index.ts
@@ -3,7 +3,6 @@ export * from './addon-providers';
 export * from './addons';
 export * from './toc';
 export * from './ipc';
-export * from './toc';
 export * from './types';
 export * from './utils';
 export * from './models';


### PR DESCRIPTION
## Summary

Three independent fixes against `release/2.22.1`. Each is a small, surgical change with no behavior change for the happy paths.

### 1. Cross-platform build & locale tests (commit 1)

- `wowup-lib/package.json` — drop hardcoded `cross-env TEMP=D:\Temp` from the parcel build script. The override broke the build everywhere except a Windows machine that happened to have `D:\Temp`. Verified: `parcel build` succeeds on macOS without the env var.
- `wowup-lib/src/index.ts` — remove duplicate `export * from './toc'` (line was present twice).
- `wowup-electron/src/locales.spec.ts` — resolve `LOCALE_DIR` from `process.cwd()` instead of walking six `..` segments from `__dirname`. After the karma+webpack bundle, that path landed inside `node_modules/electron/` on macOS, so `npm test` failed with `ENOENT` before any spec ran.

### 2. Use `browser_download_url` for github addon downloads (commit 2)

For public GitHub releases the asset's API `url` returns JSON metadata unless requested with the right `Accept` header, which trips the install/update flow. Prefer `browser_download_url` and fall back to `url` only when missing.

Refs #1248. Same one-liner as #1541 by @zol-wow — credit to them; included here so this PR's verification is self-contained, please pick whichever is easier to merge.

### 3. Show client types in import mismatch error (commit 3)

When the imported export string is for a different client group than the selected installation, populate `errorParams` with both names so the snackbar tells the user which client the export was for and which install they're importing into. The new message also points the user at re-exporting from the upgraded install.

This is the situation in #1543: an export made before TBC Anniversary support landed is labelled `Classic`, and importing it on a current Anniversary install fails with a generic "did not match" message.

Closes #1543.

## Verification

Ran on macOS (arm64), Node 22, against a fresh `npm install`:

- `npm run lint` — clean (both `angular-electron` and `e2e` projects).
- `npm run check-i18n` — no key drift (only the existing `INVALID_CLIENT_TYPE` message body changed; placeholders are no-ops in non-EN locales until those are translated).
- `npm test` — 6148 / 6148 SUCCESS.

## Test plan

- [ ] Install/update an addon from a public github repo (regression of #1541 / #1248).
- [ ] Paste an old export string from a pre-Anniversary build into an Anniversary install — confirm the new message names both client types.
- [ ] Run `npm install && npm test` from a clean checkout on Linux/Windows to confirm the locales spec resolves correctly cross-platform.