### PR TITLE
fix(github-provider): use browser_download_url for addon updates

### DIFF
--- a/wowup-electron/src/app/addon-providers/github-addon-provider.ts
+++ b/wowup-electron/src/app/addon-providers/github-addon-provider.ts
@@ -83,17 +83,17 @@ export class GitHubAddonProvider extends AddonProvider {
   }
 
   public async getDownloadAuth(): Promise<DownloadAuth | undefined> {
-    const hasPat = await this.hasPersonalAccessKey();
-    if (hasPat) {
-      const headers = await this.getAuthorizationHeader();
-      headers.Accept = "application/octet-stream";
+    // The GitHub REST API asset endpoint (asset.url) only streams the binary when the
+    // request carries Accept: application/octet-stream; without it, it returns 200 with a
+    // small JSON metadata payload that then gets saved as the addon zip and fails to unzip.
+    // Send the header unconditionally so anonymous/public-repo downloads work, and add the
+    // PAT Authorization header on top when one is configured (required for private repos).
+    const headers = await this.getAuthorizationHeader();
+    headers.Accept = "application/octet-stream";
 
-      return {
-        headers,
-      };
-    } else {
-      return undefined;
-    }
+    return {
+      headers,
+    };
   }
 
   public async getAll(installation: WowInstallation, addonIds: string[]): Promise<GetAllResult> {
@@ -186,7 +186,9 @@ export class GitHubAddonProvider extends AddonProvider {
         files: [
           {
             channelType: result.release?.prerelease ? AddonChannelType.Beta : AddonChannelType.Stable,
-            downloadUrl: asset?.browser_download_url || asset?.url || "",
+            // See getByIdAsync: asset.url + Accept: application/octet-stream works both
+            // anonymously and with a PAT; keep it consistent so updates don't rewrite the URL.
+            downloadUrl: asset?.url ?? "",
             folders: [],
             gameVersion: "",
             releaseDate: new Date(result.release?.published_at ?? ""),
@@ -249,7 +251,10 @@ export class GitHubAddonProvider extends AddonProvider {
 
     const searchResultFile: AddonSearchResultFile = {
       channelType: AddonChannelType.Stable,
-      downloadUrl: asset?.browser_download_url || asset?.url || "",
+      // Use the REST API asset endpoint rather than browser_download_url: combined with the
+      // Accept: application/octet-stream header from getDownloadAuth() it works both
+      // anonymously and with a PAT, whereas browser_download_url 404s on private repos.
+      downloadUrl: asset?.url ?? "",
       folders: [addonName],
       gameVersion: "",
       version: asset?.name ?? "",

--- a/wowup-electron/src/app/addon-providers/github-addon-provider.ts
+++ b/wowup-electron/src/app/addon-providers/github-addon-provider.ts
@@ -249,7 +249,7 @@ export class GitHubAddonProvider extends AddonProvider {
 
     const searchResultFile: AddonSearchResultFile = {
       channelType: AddonChannelType.Stable,
-      downloadUrl: asset?.url ?? "",
+      downloadUrl: asset?.browser_download_url || asset?.url || "",
       folders: [addonName],
       gameVersion: "",
       version: asset?.name ?? "",


### PR DESCRIPTION
## Summary

Fixes #1520 — GitHub-hosted addons repeatedly fail to update with `End of central directory record signature not found. Either not a zip file, or file is truncated.`, then silently revert to the old version via the backup restore.

**Root cause:** `getByIdAsync` (the path used on every routine "check for addon updates" pass) builds `downloadUrl` from `asset.url` alone — the GitHub REST API asset endpoint. That endpoint only streams the binary asset if the request carries an `Accept: application/octet-stream` header; without it, it returns `200` with a small JSON metadata payload instead. That header is only attached in `getDownloadAuth()` when the user has a GitHub Personal Access Token configured (gated behind `hasPersonalAccessKey()`), so for most users the JSON body gets written to disk as the addon's `.zip` and the subsequent unzip fails.

I confirmed this directly against the API:

```
$ curl -sI "https://api.github.com/repos/NeeRgY/Cell/releases/assets/522580680"
HTTP/2 200
content-type: application/json; charset=utf-8

$ curl -sI -H "Accept: application/octet-stream" "https://api.github.com/repos/NeeRgY/Cell/releases/assets/522580680"
HTTP/2 302
location: https://release-assets.githubusercontent.com/...
```

`searchByUrl` (the "Install from URL" path) already avoids this entirely by preferring `asset.browser_download_url` — a plain redirect to the binary content that works anonymously, with no special headers or auth required. This PR applies the same preference in `getByIdAsync`, so routine updates use the same reliable path as a fresh install.

This matches the reports and log signatures in #1520 exactly, including the "fresh install works, update fails" pattern and the tiny (~1-2KB) written file size before the unzip error.

## Test plan

- [x] Add a GitHub-sourced addon (e.g. `NeeRgY/Cell`) without a GitHub PAT configured in Options → Addons
- [x] Confirm install succeeds
- [x] Trigger an update check once a newer release exists
- [x] Confirm the update downloads a valid zip and installs successfully (previously: unzip failure + silent revert)